### PR TITLE
feat: Add figrecipe integration for reproducible figures

### DIFF
--- a/src/scitex/bridge/__init__.py
+++ b/src/scitex/bridge/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # File: ./src/scitex/bridge/__init__.py
 # Time-stamp: "2024-12-09 09:30:00 (ywatanabe)"
 """
@@ -45,6 +44,36 @@ Usage:
 """
 
 # Stats ↔ Plt bridges
+# FigRecipe integration (optional)
+from scitex.bridge._figrecipe import (
+    FIGRECIPE_AVAILABLE,
+    has_figrecipe,
+    load_recipe,
+    save_with_recipe,
+)
+
+# High-level helpers
+from scitex.bridge._helpers import (
+    add_stats_from_results,
+)
+
+# Plt ↔ Vis bridges
+from scitex.bridge._plt_vis import (
+    axes_to_vis_axes,
+    collect_figure_data,
+    figure_to_vis_model,
+    tracking_to_plot_configs,
+)
+
+# Protocol versioning
+from scitex.bridge._protocol import (
+    BRIDGE_PROTOCOL_VERSION,
+    COORDINATE_SYSTEMS,
+    ProtocolInfo,
+    add_protocol_metadata,
+    check_protocol_compatibility,
+    extract_protocol_metadata,
+)
 from scitex.bridge._stats_plt import (
     add_stat_to_axes,
     extract_stats_from_axes,
@@ -53,32 +82,9 @@ from scitex.bridge._stats_plt import (
 
 # Stats ↔ Vis bridges
 from scitex.bridge._stats_vis import (
-    stat_result_to_annotation,
     add_stats_to_figure_model,
     position_stat_annotation,
-)
-
-# Plt ↔ Vis bridges
-from scitex.bridge._plt_vis import (
-    figure_to_vis_model,
-    axes_to_vis_axes,
-    tracking_to_plot_configs,
-    collect_figure_data,
-)
-
-# High-level helpers
-from scitex.bridge._helpers import (
-    add_stats_from_results,
-)
-
-# Protocol versioning
-from scitex.bridge._protocol import (
-    BRIDGE_PROTOCOL_VERSION,
-    ProtocolInfo,
-    check_protocol_compatibility,
-    add_protocol_metadata,
-    extract_protocol_metadata,
-    COORDINATE_SYSTEMS,
+    stat_result_to_annotation,
 )
 
 __all__ = [
@@ -104,6 +110,11 @@ __all__ = [
     "collect_figure_data",
     # High-level helpers
     "add_stats_from_results",
+    # FigRecipe integration
+    "save_with_recipe",
+    "load_recipe",
+    "has_figrecipe",
+    "FIGRECIPE_AVAILABLE",
 ]
 
 

--- a/src/scitex/bridge/_figrecipe.py
+++ b/src/scitex/bridge/_figrecipe.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Bridge adapter for figrecipe integration.
+
+This module provides functions to save figures with both:
+- SigmaPlot-compatible CSV (scitex format)
+- figrecipe YAML recipe (reproducible figures)
+
+The FTS bundle structure:
+    figure/
+    ├── recipe.yaml     # Source of truth (figrecipe format)
+    ├── recipe_data/    # Large arrays (if needed)
+    ├── plot.csv        # SigmaPlot combined CSV (derived)
+    ├── plot.png        # Primary image (derived)
+    └── meta.yaml       # FTS metadata (optional)
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+# Check figrecipe availability
+try:
+    import figrecipe as fr
+    from figrecipe._serializer import save_recipe as _fr_save_recipe
+
+    FIGRECIPE_AVAILABLE = True
+except ImportError:
+    FIGRECIPE_AVAILABLE = False
+
+
+def save_with_recipe(
+    fig,
+    path: Union[str, Path],
+    include_csv: bool = True,
+    include_recipe: bool = True,
+    data_format: str = "csv",
+    dpi: int = 300,
+    **kwargs,
+) -> Dict[str, Path]:
+    """Save figure with both CSV and figrecipe recipe.
+
+    Parameters
+    ----------
+    fig : FigWrapper or matplotlib Figure
+        The figure to save.
+    path : str or Path
+        Output path. Can be:
+        - Directory path (creates bundle)
+        - File path with .zip extension (creates zip bundle)
+        - File path with image extension (saves image + sidecar files)
+    include_csv : bool
+        If True, save SigmaPlot-compatible CSV.
+    include_recipe : bool
+        If True, save figrecipe YAML recipe (requires figrecipe).
+    data_format : str
+        Format for recipe data: 'csv', 'npz', or 'inline'.
+    dpi : int
+        Resolution for image output.
+    **kwargs
+        Additional arguments passed to savefig.
+
+    Returns
+    -------
+    dict
+        Paths to saved files: {'image': Path, 'csv': Path, 'recipe': Path}
+    """
+    from scitex.fts._bundle._storage import get_storage
+
+    path = Path(path)
+    result = {}
+
+    # Determine if this is a bundle (directory or zip)
+    is_bundle = path.suffix == ".zip" or path.suffix == "" or path.is_dir()
+
+    if is_bundle:
+        # Create bundle storage
+        storage = get_storage(path)
+        storage.ensure_exists()
+
+        # Get underlying matplotlib figure
+        mpl_fig = fig._fig_mpl if hasattr(fig, "_fig_mpl") else fig
+
+        # 1. Save image
+        image_path = storage.path / "plot.png"
+        mpl_fig.savefig(image_path, dpi=dpi, **kwargs)
+        result["image"] = image_path
+
+        # 2. Save SigmaPlot CSV
+        if include_csv and hasattr(fig, "export_as_csv"):
+            try:
+                csv_df = fig.export_as_csv()
+                if not csv_df.empty:
+                    csv_path = storage.path / "plot.csv"
+                    csv_df.to_csv(csv_path, index=False)
+                    result["csv"] = csv_path
+            except Exception:
+                pass  # CSV export is optional
+
+        # 3. Save figrecipe recipe
+        if include_recipe:
+            recipe_path = _save_recipe_to_path(
+                fig, storage.path / "recipe.yaml", data_format
+            )
+            if recipe_path:
+                result["recipe"] = recipe_path
+
+    else:
+        # Single file save (image + sidecars)
+        mpl_fig = fig._fig_mpl if hasattr(fig, "_fig_mpl") else fig
+        mpl_fig.savefig(path, dpi=dpi, **kwargs)
+        result["image"] = path
+
+        # Save CSV sidecar
+        if include_csv and hasattr(fig, "export_as_csv"):
+            try:
+                csv_df = fig.export_as_csv()
+                if not csv_df.empty:
+                    csv_path = path.with_suffix(".csv")
+                    csv_df.to_csv(csv_path, index=False)
+                    result["csv"] = csv_path
+            except Exception:
+                pass
+
+        # Save recipe sidecar
+        if include_recipe:
+            recipe_path = _save_recipe_to_path(
+                fig, path.with_suffix(".yaml"), data_format
+            )
+            if recipe_path:
+                result["recipe"] = recipe_path
+
+    return result
+
+
+def _save_recipe_to_path(
+    fig,
+    path: Path,
+    data_format: str = "csv",
+) -> Optional[Path]:
+    """Save figrecipe recipe if available.
+
+    Parameters
+    ----------
+    fig : FigWrapper
+        Figure with optional _figrecipe_recorder attribute.
+    path : Path
+        Output path for recipe.yaml.
+    data_format : str
+        Format for data: 'csv', 'npz', or 'inline'.
+
+    Returns
+    -------
+    Path or None
+        Path to saved recipe, or None if not available.
+    """
+    if not FIGRECIPE_AVAILABLE:
+        return None
+
+    try:
+        # Check if figure has figrecipe recorder
+        if hasattr(fig, "_figrecipe_recorder") and fig._figrecipe_enabled:
+            recorder = fig._figrecipe_recorder
+            figure_record = recorder.figure_record
+
+            # Capture current figure state into record
+            _capture_figure_state(fig, figure_record)
+
+            # Save using figrecipe's serializer
+            _fr_save_recipe(
+                figure_record, path, include_data=True, data_format=data_format
+            )
+            return path
+
+        # Alternative: if figure was created with fr.subplots() directly
+        if hasattr(fig, "save_recipe"):
+            fig.save_recipe(path, include_data=True, data_format=data_format)
+            return path
+
+    except Exception:
+        pass  # Recipe saving is optional
+
+    return None
+
+
+def _capture_figure_state(fig, figure_record):
+    """Capture current figure state into the record.
+
+    This syncs the matplotlib figure state with the figrecipe record,
+    ensuring the recipe reflects the final figure appearance.
+    """
+    try:
+        mpl_fig = fig._fig_mpl if hasattr(fig, "_fig_mpl") else fig
+
+        # Update figure dimensions
+        figsize = mpl_fig.get_size_inches()
+        figure_record.figsize = list(figsize)
+        figure_record.dpi = int(mpl_fig.dpi)
+
+        # Capture style from scitex metadata if available
+        if hasattr(mpl_fig, "_scitex_theme"):
+            if not hasattr(figure_record, "style") or figure_record.style is None:
+                figure_record.style = {}
+            figure_record.style["theme"] = mpl_fig._scitex_theme
+
+    except Exception:
+        pass  # Non-critical
+
+
+def load_recipe(
+    path: Union[str, Path],
+) -> Any:
+    """Load figrecipe recipe from FTS bundle.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to bundle directory, zip file, or recipe.yaml.
+
+    Returns
+    -------
+    tuple
+        (fig, axes) reproduced from recipe.
+    """
+    if not FIGRECIPE_AVAILABLE:
+        raise ImportError("figrecipe is required for loading recipes")
+
+    path = Path(path)
+
+    # Handle bundle paths
+    if path.is_dir():
+        recipe_path = path / "recipe.yaml"
+    elif path.suffix == ".zip":
+        # figrecipe can handle zip files directly
+        recipe_path = path
+    else:
+        recipe_path = path
+
+    return fr.reproduce(recipe_path)
+
+
+def has_figrecipe() -> bool:
+    """Check if figrecipe is available."""
+    return FIGRECIPE_AVAILABLE
+
+
+# EOF

--- a/src/scitex/plt/_subplots/_SubplotsWrapper.py
+++ b/src/scitex/plt/_subplots/_SubplotsWrapper.py
@@ -1,86 +1,45 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# Timestamp: "2025-05-29 03:46:53 (ywatanabe)"
-# File: /ssh:ywatanabe@sp:/home/ywatanabe/proj/scitex_repo/src/scitex/plt/_subplots/_SubplotsWrapper.py
-# ----------------------------------------
+"""SubplotsWrapper: Monitor data plotted using matplotlib for CSV export."""
+
 import os
-
-__FILE__ = "./src/scitex/plt/_subplots/_SubplotsWrapper.py"
-__DIR__ = os.path.dirname(__FILE__)
-# ----------------------------------------
-
 from collections import OrderedDict
 
 import matplotlib.pyplot as plt
-import numpy as np
 
-from ._AxesWrapper import AxesWrapper
-from ._AxisWrapper import AxisWrapper
-from ._FigWrapper import FigWrapper
+__FILE__ = "./src/scitex/plt/_subplots/_SubplotsWrapper.py"
+__DIR__ = os.path.dirname(__FILE__)
 
-# Register Arial fonts at module import
-import matplotlib.font_manager as fm
-import matplotlib as mpl
-import os
-
-_arial_enabled = False
-
-# Try to find Arial
-try:
-    fm.findfont("Arial", fallback_to_default=False)
-    _arial_enabled = True
-except Exception:
-    # Search for Arial font files and register them
-    arial_paths = [
-        f
-        for f in fm.findSystemFonts()
-        if os.path.basename(f).lower().startswith("arial")
-    ]
-
-    if arial_paths:
-        for path in arial_paths:
-            try:
-                fm.fontManager.addfont(path)
-            except Exception:
-                pass
-
-        # Verify Arial is now available
-        try:
-            fm.findfont("Arial", fallback_to_default=False)
-            _arial_enabled = True
-        except Exception:
-            pass
-
-# Configure matplotlib to use Arial if available
-if _arial_enabled:
-    mpl.rcParams["font.family"] = "Arial"
-    mpl.rcParams["font.sans-serif"] = [
-        "Arial",
-        "Helvetica",
-        "DejaVu Sans",
-        "Liberation Sans",
-    ]
-else:
-    # Warn about missing Arial
-    from scitex import logging as _logging
-
-    _logger = _logging.getLogger(__name__)
-    _logger.warning(
-        "Arial font not found. Using fallback fonts (Helvetica/DejaVu Sans). "
-        "For publication figures with Arial: sudo apt-get install ttf-mscorefonts-installer && fc-cache -fv"
-    )
+# Configure fonts at import
+from ._fonts import _arial_enabled  # noqa: F401
+from ._mm_layout import create_with_mm_control
 
 
 class SubplotsWrapper:
     """
     A wrapper class monitors data plotted using the ax methods from matplotlib.pyplot.
     This data can be converted into a CSV file formatted for SigmaPlot compatibility.
+
+    Supports optional figrecipe integration for reproducible figures.
+    When figrecipe is available and `use_figrecipe=True`, figures are created
+    with recipe recording capability for later reproduction.
     """
 
     def __init__(self):
         self._subplots_wrapper_history = OrderedDict()
         self._fig_scitex = None
         self._counter_part = plt.subplots
+        self._figrecipe_available = None  # Lazy check
+
+    def _check_figrecipe(self):
+        """Check if figrecipe is available (lazy, cached)."""
+        if self._figrecipe_available is None:
+            try:
+                import figrecipe  # noqa: F401
+
+                self._figrecipe_available = True
+            except ImportError:
+                self._figrecipe_available = False
+        return self._figrecipe_available
 
     def __call__(
         self,
@@ -89,6 +48,7 @@ class SubplotsWrapper:
         sharex=False,
         sharey=False,
         constrained_layout=None,
+        use_figrecipe=None,  # NEW: Enable figrecipe recording
         # MM-control parameters (unified style system)
         axes_width_mm=None,
         axes_height_mm=None,
@@ -111,9 +71,9 @@ class SubplotsWrapper:
         n_ticks=None,
         mode=None,
         dpi=None,
-        styles=None,  # List of style dicts for per-axes control
-        transparent=None,  # Transparent background (default: from SCITEX_STYLE.yaml)
-        theme=None,  # Color theme: "light" or "dark" (default: "light")
+        styles=None,
+        transparent=None,
+        theme=None,
         **kwargs,
     ):
         """
@@ -125,104 +85,33 @@ class SubplotsWrapper:
             nrows, ncols passed to matplotlib.pyplot.subplots
         track : bool, optional
             Track plotting operations for CSV export (default: True)
-        sharex, sharey : bool, optional
-            Share axes (default: False)
-        constrained_layout : dict or None, optional
-            Layout engine parameters
+        use_figrecipe : bool or None, optional
+            If True, use figrecipe for recipe recording.
+            If None (default), auto-detect figrecipe availability.
+            If False, disable figrecipe even if available.
 
-        MM-Control Parameters (Unified Style System)
-        ---------------------------------------------
-        axes_width_mm : float or list, optional
-            Axes width in mm (single value for all, or list for each)
-        axes_height_mm : float or list, optional
-            Axes height in mm (single value for all, or list for each)
-        margin_left_mm : float, optional
-            Left margin in mm (default: 5.0)
-        margin_right_mm : float, optional
-            Right margin in mm (default: 2.0)
-        margin_bottom_mm : float, optional
-            Bottom margin in mm (default: 5.0)
-        margin_top_mm : float, optional
-            Top margin in mm (default: 2.0)
-        space_w_mm : float, optional
-            Horizontal spacing between axes in mm (default: 3.0)
-        space_h_mm : float, optional
-            Vertical spacing between axes in mm (default: 3.0)
-        axes_thickness_mm : float, optional
-            Axes spine thickness in mm
-        tick_length_mm : float, optional
-            Tick length in mm
-        tick_thickness_mm : float, optional
-            Tick thickness in mm
-        trace_thickness_mm : float, optional
-            Plot line thickness in mm
-        axis_font_size_pt : float, optional
-            Axis label font size in points
-        tick_font_size_pt : float, optional
-            Tick label font size in points
-        mode : str, optional
-            'publication' or 'display' (default: None, uses standard matplotlib)
-        dpi : int, optional
-            Resolution (default: 300 for publication, 100 for display)
-        styles : list of dict, optional
-            Individual style dicts for each axes
-        transparent : bool, optional
-            Create figure with transparent background (default: False)
-            Useful for publication-ready figures that will be cropped
-        theme : str, optional
-            Color theme: "light" or "dark" (default: "light")
-            Dark mode uses eye-friendly colors optimized for dark backgrounds
-        **kwargs
-            Additional arguments passed to matplotlib.pyplot.subplots
+        MM-Control Parameters
+        ---------------------
+        axes_width_mm, axes_height_mm : float or list
+            Axes dimensions in mm
+        margin_*_mm : float
+            Figure margins in mm
+        space_w_mm, space_h_mm : float
+            Spacing between axes in mm
+        mode : str
+            'publication' or 'display'
 
         Returns
         -------
         fig : FigWrapper
-            Wrapped matplotlib Figure
+            Wrapped matplotlib Figure (with optional RecordingFigure)
         ax or axes : AxisWrapper or AxesWrapper
             Wrapped matplotlib Axes
-
-        Examples
-        --------
-        Single axes with style:
-
-        >>> fig, ax = stx.plt.subplots(
-        ...     axes_width_mm=30,
-        ...     axes_height_mm=21,
-        ...     axes_thickness_mm=0.2,
-        ...     tick_length_mm=0.8,
-        ...     mode='publication'
-        ... )
-
-        Multiple axes with uniform style:
-
-        >>> fig, axes = stx.plt.subplots(
-        ...     nrows=2, ncols=3,
-        ...     axes_width_mm=30,
-        ...     axes_height_mm=21,
-        ...     space_w_mm=3,
-        ...     space_h_mm=3,
-        ...     mode='publication'
-        ... )
-
-        Using style preset:
-
-        >>> NATURE_STYLE = {
-        ...     'axes_width_mm': 30,
-        ...     'axes_height_mm': 21,
-        ...     'axes_thickness_mm': 0.2,
-        ...     'tick_length_mm': 0.8,
-        ... }
-        >>> fig, ax = stx.plt.subplots(**NATURE_STYLE)
         """
+        # Resolve style values
+        from scitex.plt.styles import SCITEX_STYLE as _S
+        from scitex.plt.styles import resolve_style_value as _resolve
 
-        # Use resolve_style_value for priority: direct → yaml → env → default
-        from scitex.plt.styles import (
-            resolve_style_value as _resolve,
-            SCITEX_STYLE as _S,
-        )
-
-        # Resolve all style values with proper priority chain
         axes_width_mm = _resolve(
             "axes.width_mm", axes_width_mm, _S.get("axes_width_mm")
         )
@@ -275,420 +164,114 @@ class SubplotsWrapper:
         )
         n_ticks = _resolve("ticks.n_ticks", n_ticks, _S.get("n_ticks"), int)
         dpi = _resolve("output.dpi", dpi, _S.get("dpi"), int)
-        # Resolve transparent from YAML (default: True in SCITEX_STYLE.yaml)
+
         if transparent is None:
             transparent = _S.get("transparent", True)
         if mode is None:
             mode = _S.get("mode", "publication")
-        # Resolve theme from YAML (default: "light")
         if theme is None:
             theme = _resolve("theme.mode", None, "light", str)
 
-        # Always use mm-control pathway with SCITEX_STYLE defaults
-        if True:
-            # Use mm-control pathway
-            return self._create_with_mm_control(
-                *args,
-                track=track,
-                sharex=sharex,
-                sharey=sharey,
-                axes_width_mm=axes_width_mm,
-                axes_height_mm=axes_height_mm,
-                margin_left_mm=margin_left_mm,
-                margin_right_mm=margin_right_mm,
-                margin_bottom_mm=margin_bottom_mm,
-                margin_top_mm=margin_top_mm,
-                space_w_mm=space_w_mm,
-                space_h_mm=space_h_mm,
-                axes_thickness_mm=axes_thickness_mm,
-                tick_length_mm=tick_length_mm,
-                tick_thickness_mm=tick_thickness_mm,
-                trace_thickness_mm=trace_thickness_mm,
-                marker_size_mm=marker_size_mm,
-                axis_font_size_pt=axis_font_size_pt,
-                tick_font_size_pt=tick_font_size_pt,
-                title_font_size_pt=title_font_size_pt,
-                legend_font_size_pt=legend_font_size_pt,
-                suptitle_font_size_pt=suptitle_font_size_pt,
-                n_ticks=n_ticks,
-                mode=mode,
-                dpi=dpi,
-                styles=styles,
-                transparent=transparent,
-                theme=theme,
-                **kwargs,
-            )
+        # Determine figrecipe usage
+        if use_figrecipe is None:
+            use_figrecipe = self._check_figrecipe()
 
-    def _create_with_mm_control(
-        self,
-        *args,
-        track=True,
-        sharex=False,
-        sharey=False,
-        axes_width_mm=None,
-        axes_height_mm=None,
-        margin_left_mm=None,
-        margin_right_mm=None,
-        margin_bottom_mm=None,
-        margin_top_mm=None,
-        space_w_mm=None,
-        space_h_mm=None,
-        axes_thickness_mm=None,
-        tick_length_mm=None,
-        tick_thickness_mm=None,
-        trace_thickness_mm=None,
-        marker_size_mm=None,
-        axis_font_size_pt=None,
-        tick_font_size_pt=None,
-        title_font_size_pt=None,
-        legend_font_size_pt=None,
-        suptitle_font_size_pt=None,
-        label_pad_pt=None,
-        tick_pad_pt=None,
-        title_pad_pt=None,
-        font_family=None,
-        n_ticks=None,
-        mode=None,
-        dpi=None,
-        styles=None,
-        transparent=None,  # Resolved from caller
-        theme=None,  # Color theme: "light" or "dark"
-        **kwargs,
-    ):
-        """Create figure with mm-based control over axes dimensions."""
-        from scitex.plt.utils import mm_to_inch, apply_style_mm
-
-        # Parse nrows, ncols from args or kwargs (like matplotlib.pyplot.subplots)
-        nrows, ncols = 1, 1
-        if len(args) >= 1:
-            nrows = args[0]
-        elif "nrows" in kwargs:
-            nrows = kwargs.pop("nrows")
-        if len(args) >= 2:
-            ncols = args[1]
-        elif "ncols" in kwargs:
-            ncols = kwargs.pop("ncols")
-
-        n_axes = nrows * ncols
-
-        # Apply mode-specific defaults
-        if mode == "display":
-            scale_factor = 3.0
-            dpi = dpi or 100
-        else:  # publication or None
-            scale_factor = 1.0
-            dpi = dpi or 300
-
-        # Set defaults - if value is provided, apply scaling; if not, use scaled default
-        if axes_width_mm is None:
-            axes_width_mm = 30.0 * scale_factor
-        elif mode == "display":
-            axes_width_mm = axes_width_mm * scale_factor
-
-        if axes_height_mm is None:
-            axes_height_mm = 21.0 * scale_factor
-        elif mode == "display":
-            axes_height_mm = axes_height_mm * scale_factor
-
-        margin_left_mm = (
-            margin_left_mm if margin_left_mm is not None else (5.0 * scale_factor)
-        )
-        margin_right_mm = (
-            margin_right_mm if margin_right_mm is not None else (2.0 * scale_factor)
-        )
-        margin_bottom_mm = (
-            margin_bottom_mm if margin_bottom_mm is not None else (5.0 * scale_factor)
-        )
-        margin_top_mm = (
-            margin_top_mm if margin_top_mm is not None else (2.0 * scale_factor)
-        )
-        space_w_mm = space_w_mm if space_w_mm is not None else (3.0 * scale_factor)
-        space_h_mm = space_h_mm if space_h_mm is not None else (3.0 * scale_factor)
-
-        # Handle list vs scalar for axes_width_mm and axes_height_mm
-        if isinstance(axes_width_mm, (list, tuple)):
-            ax_widths_mm = list(axes_width_mm)
-            if len(ax_widths_mm) != n_axes:
-                raise ValueError(
-                    f"axes_width_mm list length ({len(ax_widths_mm)}) must match nrows*ncols ({n_axes})"
-                )
-        else:
-            ax_widths_mm = [axes_width_mm] * n_axes
-
-        if isinstance(axes_height_mm, (list, tuple)):
-            ax_heights_mm = list(axes_height_mm)
-            if len(ax_heights_mm) != n_axes:
-                raise ValueError(
-                    f"axes_height_mm list length ({len(ax_heights_mm)}) must match nrows*ncols ({n_axes})"
-                )
-        else:
-            ax_heights_mm = [axes_height_mm] * n_axes
-
-        # Calculate figure size from axes grid
-        # For simplicity, use max width per column and max height per row
-        ax_widths_2d = np.array(ax_widths_mm).reshape(nrows, ncols)
-        ax_heights_2d = np.array(ax_heights_mm).reshape(nrows, ncols)
-
-        max_widths_per_col = ax_widths_2d.max(axis=0)  # Max width in each column
-        max_heights_per_row = ax_heights_2d.max(axis=1)  # Max height in each row
-
-        total_width_mm = (
-            margin_left_mm
-            + max_widths_per_col.sum()
-            + (ncols - 1) * space_w_mm
-            + margin_right_mm
-        )
-        total_height_mm = (
-            margin_bottom_mm
-            + max_heights_per_row.sum()
-            + (nrows - 1) * space_h_mm
-            + margin_top_mm
+        # Create figure with mm-control
+        fig, axes = create_with_mm_control(
+            *args,
+            track=track,
+            sharex=sharex,
+            sharey=sharey,
+            axes_width_mm=axes_width_mm,
+            axes_height_mm=axes_height_mm,
+            margin_left_mm=margin_left_mm,
+            margin_right_mm=margin_right_mm,
+            margin_bottom_mm=margin_bottom_mm,
+            margin_top_mm=margin_top_mm,
+            space_w_mm=space_w_mm,
+            space_h_mm=space_h_mm,
+            axes_thickness_mm=axes_thickness_mm,
+            tick_length_mm=tick_length_mm,
+            tick_thickness_mm=tick_thickness_mm,
+            trace_thickness_mm=trace_thickness_mm,
+            marker_size_mm=marker_size_mm,
+            axis_font_size_pt=axis_font_size_pt,
+            tick_font_size_pt=tick_font_size_pt,
+            title_font_size_pt=title_font_size_pt,
+            legend_font_size_pt=legend_font_size_pt,
+            suptitle_font_size_pt=suptitle_font_size_pt,
+            n_ticks=n_ticks,
+            mode=mode,
+            dpi=dpi,
+            styles=styles,
+            transparent=transparent,
+            theme=theme,
+            **kwargs,
         )
 
-        # Create figure with calculated size
-        figsize_inch = (mm_to_inch(total_width_mm), mm_to_inch(total_height_mm))
-        if transparent:
-            # Transparent background for publication figures
-            self._fig_mpl = plt.figure(figsize=figsize_inch, dpi=dpi, facecolor="none")
-        else:
-            self._fig_mpl = plt.figure(figsize=figsize_inch, dpi=dpi)
+        # If figrecipe enabled, create recording layer
+        if use_figrecipe:
+            self._attach_figrecipe_recorder(fig)
 
-        # Store theme on figure for later retrieval (e.g., when saving plot.json)
-        if theme is not None:
-            self._fig_mpl._scitex_theme = theme
+        self._fig_scitex = fig
+        return fig, axes
 
-        # Create axes array and position each one manually
-        axes_mpl_list = []
-        ax_idx = 0
+    def _attach_figrecipe_recorder(self, fig_wrapper):
+        """Attach figrecipe recorder to FigWrapper for recipe export.
 
-        for row in range(nrows):
-            for col in range(ncols):
-                # Calculate position for this axes
-                # Left position: left margin + sum of previous column widths + spacing
-                left_mm = (
-                    margin_left_mm + max_widths_per_col[:col].sum() + col * space_w_mm
-                )
-
-                # Bottom position: bottom margin + sum of heights above this row + spacing
-                # (rows are counted from top in matplotlib)
-                rows_below = nrows - row - 1
-                bottom_mm = (
-                    margin_bottom_mm
-                    + max_heights_per_row[row + 1 :].sum()
-                    + rows_below * space_h_mm
-                )
-
-                # Convert to figure coordinates [0-1]
-                left = left_mm / total_width_mm
-                bottom = bottom_mm / total_height_mm
-                width = ax_widths_mm[ax_idx] / total_width_mm
-                height = ax_heights_mm[ax_idx] / total_height_mm
-
-                # Create axes at exact position with transparent background
-                ax_mpl = self._fig_mpl.add_axes([left, bottom, width, height])
-                if transparent:
-                    ax_mpl.patch.set_alpha(0.0)  # Make axes background transparent
-                axes_mpl_list.append(ax_mpl)
-
-                # Tag with metadata
-                ax_mpl._scitex_metadata = {
-                    "created_with": "scitex.plt.subplots",
-                    "mode": mode or "publication",
-                    "axes_size_mm": (ax_widths_mm[ax_idx], ax_heights_mm[ax_idx]),
-                    "position_in_grid": (row, col),
-                }
-
-                ax_idx += 1
-
-        # Apply styling to each axes
-        suptitle_font_size_pt = None
-        for i, ax_mpl in enumerate(axes_mpl_list):
-            # Determine which style dict to use
-            if styles is not None:
-                if isinstance(styles, list):
-                    if len(styles) != n_axes:
-                        raise ValueError(
-                            f"styles list length ({len(styles)}) must match nrows*ncols ({n_axes})"
-                        )
-                    style_dict = styles[i]
-                else:
-                    style_dict = styles
-            else:
-                # Build style dict from individual parameters
-                style_dict = {}
-                if axes_thickness_mm is not None:
-                    style_dict["axis_thickness_mm"] = axes_thickness_mm
-                if tick_length_mm is not None:
-                    style_dict["tick_length_mm"] = tick_length_mm
-                if tick_thickness_mm is not None:
-                    style_dict["tick_thickness_mm"] = tick_thickness_mm
-                if trace_thickness_mm is not None:
-                    style_dict["trace_thickness_mm"] = trace_thickness_mm
-                if marker_size_mm is not None:
-                    style_dict["marker_size_mm"] = marker_size_mm
-                if axis_font_size_pt is not None:
-                    style_dict["axis_font_size_pt"] = axis_font_size_pt
-                if tick_font_size_pt is not None:
-                    style_dict["tick_font_size_pt"] = tick_font_size_pt
-                if title_font_size_pt is not None:
-                    style_dict["title_font_size_pt"] = title_font_size_pt
-                if legend_font_size_pt is not None:
-                    style_dict["legend_font_size_pt"] = legend_font_size_pt
-                if suptitle_font_size_pt is not None:
-                    style_dict["suptitle_font_size_pt"] = suptitle_font_size_pt
-                if label_pad_pt is not None:
-                    style_dict["label_pad_pt"] = label_pad_pt
-                if tick_pad_pt is not None:
-                    style_dict["tick_pad_pt"] = tick_pad_pt
-                if title_pad_pt is not None:
-                    style_dict["title_pad_pt"] = title_pad_pt
-                if font_family is not None:
-                    style_dict["font_family"] = font_family
-                if n_ticks is not None:
-                    style_dict["n_ticks"] = n_ticks
-
-            # Always add theme to style_dict (default: "light")
-            if theme is not None:
-                style_dict["theme"] = theme
-
-            # Extract suptitle font size if available
-            if "suptitle_font_size_pt" in style_dict:
-                suptitle_font_size_pt_value = style_dict["suptitle_font_size_pt"]
-            else:
-                suptitle_font_size_pt_value = None
-
-            # Apply style if not empty
-            if style_dict:
-                apply_style_mm(ax_mpl, style_dict)
-                # Add style to metadata
-                ax_mpl._scitex_metadata["style_mm"] = style_dict
-
-        # Store suptitle font size in figure metadata for later use
-        if suptitle_font_size_pt_value is not None:
-            self._fig_mpl._scitex_suptitle_font_size_pt = suptitle_font_size_pt_value
-
-        # Wrap the figure
-        self._fig_scitex = FigWrapper(self._fig_mpl)
-
-        # Reshape axes list to match grid shape
-        axes_array_mpl = np.array(axes_mpl_list).reshape(nrows, ncols)
-
-        # Handle single axis case
-        if n_axes == 1:
-            ax_mpl_scalar = axes_array_mpl.item()
-            self._axis_scitex = AxisWrapper(self._fig_scitex, ax_mpl_scalar, track)
-            # ALWAYS use list for consistency with matplotlib (fig.axes is always a list)
-            self._fig_scitex.axes = [self._axis_scitex]
-            # Store reference to scitex wrapper on matplotlib axes for metadata collection
-            ax_mpl_scalar._scitex_wrapper = self._axis_scitex
-            return self._fig_scitex, self._axis_scitex
-
-        # Handle multiple axes case
-        axes_flat_scitex_list = []
-        for ax_mpl in axes_mpl_list:
-            ax_scitex = AxisWrapper(self._fig_scitex, ax_mpl, track)
-            # Store reference to scitex wrapper on matplotlib axes for metadata collection
-            ax_mpl._scitex_wrapper = ax_scitex
-            axes_flat_scitex_list.append(ax_scitex)
-
-        axes_array_scitex = np.array(axes_flat_scitex_list).reshape(nrows, ncols)
-        self._axes_scitex = AxesWrapper(self._fig_scitex, axes_array_scitex)
-        self._fig_scitex.axes = self._axes_scitex
-
-        return self._fig_scitex, self._axes_scitex
-
-    # def __getattr__(self, name):
-    #     """
-    #     Fallback to fetch attributes from the original matplotlib.pyplot.subplots function
-    #     if they are not defined directly in this wrapper instance.
-    #     This allows accessing attributes like __name__, __doc__ etc. from the original function.
-    #     """
-    #     print(f"Attribute of SubplotsWrapper: {name}")
-    #     # Check if the attribute exists in the counterpart function
-    #     if hasattr(self._counter_part, name):
-    #         return getattr(self._counter_part, name)
-    #     # Raise the standard error if not found in the wrapper or the counterpart
-    #     raise AttributeError(
-    #         f"'{type(self).__name__}' object and its counterpart '{self._counter_part.__name__}' have no attribute '{name}'"
-    #     )
-
-    def __dir__(
-        self,
-    ):
+        This creates a RecordingFigure layer that wraps the underlying
+        matplotlib figure, enabling save_recipe() on the FigWrapper.
         """
-        Provide combined directory for tab completion, including
-        attributes from this wrapper and the original matplotlib.pyplot.subplots function.
-        """
-        # Get attributes defined explicitly in this instance/class
+        try:
+            from figrecipe._recorder import Recorder
+
+            # Get the underlying matplotlib figure
+            mpl_fig = fig_wrapper._fig_mpl
+
+            # Create recorder
+            recorder = Recorder()
+            figsize = mpl_fig.get_size_inches()
+            dpi_val = mpl_fig.dpi
+            recorder.start_figure(figsize=tuple(figsize), dpi=int(dpi_val))
+
+            # Store recorder on FigWrapper for later recipe export
+            fig_wrapper._figrecipe_recorder = recorder
+            fig_wrapper._figrecipe_enabled = True
+
+            # Store style info from scitex in the recipe
+            if hasattr(mpl_fig, "_scitex_theme"):
+                recorder.figure_record.style = {"theme": mpl_fig._scitex_theme}
+
+        except Exception:
+            # Silently fail - figrecipe is optional
+            fig_wrapper._figrecipe_enabled = False
+
+    def __dir__(self):
+        """Provide combined directory for tab completion."""
         local_attrs = set(super().__dir__())
-        # Get attributes from the counterpart function
         try:
             counterpart_attrs = set(dir(self._counter_part))
         except Exception:
             counterpart_attrs = set()
-        # Return the sorted union
         return sorted(local_attrs.union(counterpart_attrs))
 
 
-# Instantiate the wrapper. This instance will be imported and used.
+# Instantiate the wrapper
 subplots = SubplotsWrapper()
+
 
 if __name__ == "__main__":
     import matplotlib
+
     import scitex
 
-    matplotlib.use("TkAgg")  # "TkAgg"
+    matplotlib.use("TkAgg")
 
     fig, ax = subplots()
     ax.plot([1, 2, 3], [4, 5, 6], id="plot1")
     ax.plot([4, 5, 6], [1, 2, 3], id="plot2")
     scitex.io.save(fig, "/tmp/subplots_demo/plots.png")
 
-    # Behaves like native matplotlib.pyplot.subplots without tracking
-    fig, ax = subplots(track=False)
-    ax.plot([1, 2, 3], [4, 5, 6], id="plot3")
-    ax.plot([4, 5, 6], [1, 2, 3], id="plot4")
-    scitex.io.save(fig, "/tmp/subplots_demo/plots.png")
-
-    fig, ax = subplots()
-    ax.scatter([1, 2, 3], [4, 5, 6], id="scatter1")
-    ax.scatter([4, 5, 6], [1, 2, 3], id="scatter2")
-    scitex.io.save(fig, "/tmp/subplots_demo/scatters.png")
-
-    fig, ax = subplots()
-    ax.boxplot([1, 2, 3], id="boxplot1")
-    scitex.io.save(fig, "/tmp/subplots_demo/boxplot1.png")
-
-    fig, ax = subplots()
-    ax.bar(["A", "B", "C"], [4, 5, 6], id="bar1")
-    scitex.io.save(fig, "/tmp/subplots_demo/bar1.png")
-
     print(ax.export_as_csv())
-    #    plot1_plot_x  plot1_plot_y  plot2_plot_x  ...  boxplot1_boxplot_x  bar1_bar_x  bar1_bar_y
-    # 0           1.0           4.0           4.0  ...                 1.0           A         4.0
-    # 1           2.0           5.0           5.0  ...                 2.0           B         5.0
-    # 2           3.0           6.0           6.0  ...                 3.0           C         6.0
-
-    print(ax.export_as_csv().keys())  # plot3 and plot 4 are not tracked
-    # [3 rows x 11 columns]
-    # Index(['plot1_plot_x', 'plot1_plot_y', 'plot2_plot_x', 'plot2_plot_y',
-    #        'scatter1_scatter_x', 'scatter1_scatter_y', 'scatter2_scatter_x',
-    #        'scatter2_scatter_y', 'boxplot1_boxplot_x', 'bar1_bar_x', 'bar1_bar_y'],
-    #       dtype='object')
-
-    # If a path is passed, the sigmaplot-friendly dataframe is saved as a csv file.
-    ax.export_as_csv("./tmp/subplots_demo/for_sigmaplot.csv")
-    # Saved to: ./tmp/subplots_demo/for_sigmaplot.csv
-
-"""
-from matplotlib.pyplot import subplots as counter_part
-from scitex.plt import subplots as msubplots
-print(set(dir(msubplots)) - set(dir(counter_part)))
-is_compatible = np.all([kk in set(dir(msubplots)) for kk in set(dir(counter_part))])
-if is_compatible:
-    print(f"{msubplots.__name__} is compatible with {counter_part.__name__}")
-else:
-    print(f"{msubplots.__name__} is incompatible with {counter_part.__name__}")
-"""
 
 # EOF

--- a/src/scitex/plt/_subplots/_fonts.py
+++ b/src/scitex/plt/_subplots/_fonts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Font configuration for matplotlib figures."""
+
+import os
+
+import matplotlib as mpl
+import matplotlib.font_manager as fm
+
+
+def configure_arial_font():
+    """Configure Arial font for matplotlib if available.
+
+    Returns
+    -------
+    bool
+        True if Arial was successfully configured, False otherwise.
+    """
+    arial_enabled = False
+
+    # Try to find Arial
+    try:
+        fm.findfont("Arial", fallback_to_default=False)
+        arial_enabled = True
+    except Exception:
+        # Search for Arial font files and register them
+        arial_paths = [
+            f
+            for f in fm.findSystemFonts()
+            if os.path.basename(f).lower().startswith("arial")
+        ]
+
+        if arial_paths:
+            for path in arial_paths:
+                try:
+                    fm.fontManager.addfont(path)
+                except Exception:
+                    pass
+
+            # Verify Arial is now available
+            try:
+                fm.findfont("Arial", fallback_to_default=False)
+                arial_enabled = True
+            except Exception:
+                pass
+
+    # Configure matplotlib to use Arial if available
+    if arial_enabled:
+        mpl.rcParams["font.family"] = "Arial"
+        mpl.rcParams["font.sans-serif"] = [
+            "Arial",
+            "Helvetica",
+            "DejaVu Sans",
+            "Liberation Sans",
+        ]
+    else:
+        # Warn about missing Arial
+        from scitex import logging as _logging
+
+        _logger = _logging.getLogger(__name__)
+        _logger.warning(
+            "Arial font not found. Using fallback fonts (Helvetica/DejaVu Sans). "
+            "For publication figures with Arial: sudo apt-get install ttf-mscorefonts-installer && fc-cache -fv"
+        )
+
+    return arial_enabled
+
+
+# Configure fonts at module import
+_arial_enabled = configure_arial_font()
+
+# EOF

--- a/src/scitex/plt/_subplots/_mm_layout.py
+++ b/src/scitex/plt/_subplots/_mm_layout.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Millimeter-based layout control for matplotlib figures."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ._AxesWrapper import AxesWrapper
+from ._AxisWrapper import AxisWrapper
+from ._FigWrapper import FigWrapper
+
+
+def create_with_mm_control(
+    *args,
+    track=True,
+    sharex=False,
+    sharey=False,
+    axes_width_mm=None,
+    axes_height_mm=None,
+    margin_left_mm=None,
+    margin_right_mm=None,
+    margin_bottom_mm=None,
+    margin_top_mm=None,
+    space_w_mm=None,
+    space_h_mm=None,
+    axes_thickness_mm=None,
+    tick_length_mm=None,
+    tick_thickness_mm=None,
+    trace_thickness_mm=None,
+    marker_size_mm=None,
+    axis_font_size_pt=None,
+    tick_font_size_pt=None,
+    title_font_size_pt=None,
+    legend_font_size_pt=None,
+    suptitle_font_size_pt=None,
+    label_pad_pt=None,
+    tick_pad_pt=None,
+    title_pad_pt=None,
+    font_family=None,
+    n_ticks=None,
+    mode=None,
+    dpi=None,
+    styles=None,
+    transparent=None,
+    theme=None,
+    **kwargs,
+):
+    """Create figure with mm-based control over axes dimensions.
+
+    Returns
+    -------
+    tuple
+        (FigWrapper, AxisWrapper or AxesWrapper)
+    """
+    from scitex.plt.utils import apply_style_mm, mm_to_inch
+
+    # Parse nrows, ncols from args or kwargs
+    nrows, ncols = 1, 1
+    if len(args) >= 1:
+        nrows = args[0]
+    elif "nrows" in kwargs:
+        nrows = kwargs.pop("nrows")
+    if len(args) >= 2:
+        ncols = args[1]
+    elif "ncols" in kwargs:
+        ncols = kwargs.pop("ncols")
+
+    n_axes = nrows * ncols
+
+    # Apply mode-specific defaults
+    if mode == "display":
+        scale_factor = 3.0
+        dpi = dpi or 100
+    else:
+        scale_factor = 1.0
+        dpi = dpi or 300
+
+    # Set defaults with scaling
+    if axes_width_mm is None:
+        axes_width_mm = 30.0 * scale_factor
+    elif mode == "display":
+        axes_width_mm = axes_width_mm * scale_factor
+
+    if axes_height_mm is None:
+        axes_height_mm = 21.0 * scale_factor
+    elif mode == "display":
+        axes_height_mm = axes_height_mm * scale_factor
+
+    margin_left_mm = (
+        margin_left_mm if margin_left_mm is not None else (5.0 * scale_factor)
+    )
+    margin_right_mm = (
+        margin_right_mm if margin_right_mm is not None else (2.0 * scale_factor)
+    )
+    margin_bottom_mm = (
+        margin_bottom_mm if margin_bottom_mm is not None else (5.0 * scale_factor)
+    )
+    margin_top_mm = margin_top_mm if margin_top_mm is not None else (2.0 * scale_factor)
+    space_w_mm = space_w_mm if space_w_mm is not None else (3.0 * scale_factor)
+    space_h_mm = space_h_mm if space_h_mm is not None else (3.0 * scale_factor)
+
+    # Handle list vs scalar for axes dimensions
+    if isinstance(axes_width_mm, (list, tuple)):
+        ax_widths_mm = list(axes_width_mm)
+        if len(ax_widths_mm) != n_axes:
+            raise ValueError(
+                f"axes_width_mm list length ({len(ax_widths_mm)}) "
+                f"must match nrows*ncols ({n_axes})"
+            )
+    else:
+        ax_widths_mm = [axes_width_mm] * n_axes
+
+    if isinstance(axes_height_mm, (list, tuple)):
+        ax_heights_mm = list(axes_height_mm)
+        if len(ax_heights_mm) != n_axes:
+            raise ValueError(
+                f"axes_height_mm list length ({len(ax_heights_mm)}) "
+                f"must match nrows*ncols ({n_axes})"
+            )
+    else:
+        ax_heights_mm = [axes_height_mm] * n_axes
+
+    # Calculate figure size from axes grid
+    ax_widths_2d = np.array(ax_widths_mm).reshape(nrows, ncols)
+    ax_heights_2d = np.array(ax_heights_mm).reshape(nrows, ncols)
+
+    max_widths_per_col = ax_widths_2d.max(axis=0)
+    max_heights_per_row = ax_heights_2d.max(axis=1)
+
+    total_width_mm = (
+        margin_left_mm
+        + max_widths_per_col.sum()
+        + (ncols - 1) * space_w_mm
+        + margin_right_mm
+    )
+    total_height_mm = (
+        margin_bottom_mm
+        + max_heights_per_row.sum()
+        + (nrows - 1) * space_h_mm
+        + margin_top_mm
+    )
+
+    # Create figure
+    figsize_inch = (mm_to_inch(total_width_mm), mm_to_inch(total_height_mm))
+    if transparent:
+        fig_mpl = plt.figure(figsize=figsize_inch, dpi=dpi, facecolor="none")
+    else:
+        fig_mpl = plt.figure(figsize=figsize_inch, dpi=dpi)
+
+    # Store theme on figure
+    if theme is not None:
+        fig_mpl._scitex_theme = theme
+
+    # Create axes array and position each one manually
+    axes_mpl_list = []
+    ax_idx = 0
+
+    for row in range(nrows):
+        for col in range(ncols):
+            # Calculate position
+            left_mm = margin_left_mm + max_widths_per_col[:col].sum() + col * space_w_mm
+            rows_below = nrows - row - 1
+            bottom_mm = (
+                margin_bottom_mm
+                + max_heights_per_row[row + 1 :].sum()
+                + rows_below * space_h_mm
+            )
+
+            # Convert to figure coordinates [0-1]
+            left = left_mm / total_width_mm
+            bottom = bottom_mm / total_height_mm
+            width = ax_widths_mm[ax_idx] / total_width_mm
+            height = ax_heights_mm[ax_idx] / total_height_mm
+
+            # Create axes
+            ax_mpl = fig_mpl.add_axes([left, bottom, width, height])
+            if transparent:
+                ax_mpl.patch.set_alpha(0.0)
+            axes_mpl_list.append(ax_mpl)
+
+            # Tag with metadata
+            ax_mpl._scitex_metadata = {
+                "created_with": "scitex.plt.subplots",
+                "mode": mode or "publication",
+                "axes_size_mm": (ax_widths_mm[ax_idx], ax_heights_mm[ax_idx]),
+                "position_in_grid": (row, col),
+            }
+            ax_idx += 1
+
+    # Apply styling to each axes
+    suptitle_font_size_pt_value = None
+    for i, ax_mpl in enumerate(axes_mpl_list):
+        # Determine which style dict to use
+        if styles is not None:
+            if isinstance(styles, list):
+                if len(styles) != n_axes:
+                    raise ValueError(
+                        f"styles list length ({len(styles)}) "
+                        f"must match nrows*ncols ({n_axes})"
+                    )
+                style_dict = styles[i]
+            else:
+                style_dict = styles
+        else:
+            # Build style dict from individual parameters
+            style_dict = {}
+            if axes_thickness_mm is not None:
+                style_dict["axis_thickness_mm"] = axes_thickness_mm
+            if tick_length_mm is not None:
+                style_dict["tick_length_mm"] = tick_length_mm
+            if tick_thickness_mm is not None:
+                style_dict["tick_thickness_mm"] = tick_thickness_mm
+            if trace_thickness_mm is not None:
+                style_dict["trace_thickness_mm"] = trace_thickness_mm
+            if marker_size_mm is not None:
+                style_dict["marker_size_mm"] = marker_size_mm
+            if axis_font_size_pt is not None:
+                style_dict["axis_font_size_pt"] = axis_font_size_pt
+            if tick_font_size_pt is not None:
+                style_dict["tick_font_size_pt"] = tick_font_size_pt
+            if title_font_size_pt is not None:
+                style_dict["title_font_size_pt"] = title_font_size_pt
+            if legend_font_size_pt is not None:
+                style_dict["legend_font_size_pt"] = legend_font_size_pt
+            if suptitle_font_size_pt is not None:
+                style_dict["suptitle_font_size_pt"] = suptitle_font_size_pt
+            if label_pad_pt is not None:
+                style_dict["label_pad_pt"] = label_pad_pt
+            if tick_pad_pt is not None:
+                style_dict["tick_pad_pt"] = tick_pad_pt
+            if title_pad_pt is not None:
+                style_dict["title_pad_pt"] = title_pad_pt
+            if font_family is not None:
+                style_dict["font_family"] = font_family
+            if n_ticks is not None:
+                style_dict["n_ticks"] = n_ticks
+
+        # Always add theme to style_dict
+        if theme is not None:
+            style_dict["theme"] = theme
+
+        # Extract suptitle font size if available
+        if "suptitle_font_size_pt" in style_dict:
+            suptitle_font_size_pt_value = style_dict["suptitle_font_size_pt"]
+
+        # Apply style if not empty
+        if style_dict:
+            apply_style_mm(ax_mpl, style_dict)
+            ax_mpl._scitex_metadata["style_mm"] = style_dict
+
+    # Store suptitle font size in figure metadata
+    if suptitle_font_size_pt_value is not None:
+        fig_mpl._scitex_suptitle_font_size_pt = suptitle_font_size_pt_value
+
+    # Wrap the figure
+    fig_scitex = FigWrapper(fig_mpl)
+
+    # Reshape axes list
+    axes_array_mpl = np.array(axes_mpl_list).reshape(nrows, ncols)
+
+    # Handle single axis case
+    if n_axes == 1:
+        ax_mpl_scalar = axes_array_mpl.item()
+        axis_scitex = AxisWrapper(fig_scitex, ax_mpl_scalar, track)
+        fig_scitex.axes = [axis_scitex]
+        ax_mpl_scalar._scitex_wrapper = axis_scitex
+        return fig_scitex, axis_scitex
+
+    # Handle multiple axes case
+    axes_flat_scitex_list = []
+    for ax_mpl in axes_mpl_list:
+        ax_scitex = AxisWrapper(fig_scitex, ax_mpl, track)
+        ax_mpl._scitex_wrapper = ax_scitex
+        axes_flat_scitex_list.append(ax_scitex)
+
+    axes_array_scitex = np.array(axes_flat_scitex_list).reshape(nrows, ncols)
+    axes_scitex = AxesWrapper(fig_scitex, axes_array_scitex)
+    fig_scitex.axes = axes_scitex
+
+    return fig_scitex, axes_scitex
+
+
+# EOF


### PR DESCRIPTION
## Summary
- Added figrecipe as optional dependency (`pip install scitex[figures]`)
- Enhanced SubplotsWrapper with `use_figrecipe` parameter for auto-detection
- Created bridge/_figrecipe.py adapter for dual CSV + YAML export
- Updated io.save() to include recipe.yaml in FTS bundles
- Refactored SubplotsWrapper (extracted fonts and mm_layout modules)

## Bundle Structure
```
figure/
├── recipe.yaml     # Source of truth (figrecipe)
├── recipe_data/    # Large arrays (if needed)
├── plot.csv        # SigmaPlot-compatible (scitex)
├── plot.png        # Primary image
└── meta.yaml       # FTS metadata
```

## Usage
```python
fig, ax = stx.plt.subplots()  # Auto-detects figrecipe
ax.plot(x, y, id='data')
stx.io.save(fig, "figure/")   # Creates bundle with recipe.yaml
```

## Test Results
- SubplotsWrapper Tests: 9/9 PASSED
- Bridge Protocol Tests: 21/21 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)