### PR TITLE
fix(deps): Pin umap-learn>=0.5.4 for Python 3.11+ - v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to SciTeX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.2] - 2026-01-06
+
+### Fixed
+- **Dependency**: Pin `umap-learn>=0.5.4` for Python 3.11+ compatibility (llvmlite issue)
+
+## [2.10.1] - 2026-01-06
+
+### Fixed
+- **Documentation**: Updated README to recommend `scitex[all]` as primary installation
+
 ## [2.10.0] - 2026-01-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.10.1"
+version = "2.10.2"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -418,7 +418,7 @@ ml = [
     "scikit-learn",
     "scikit-image",
     "imbalanced-learn",
-    "umap-learn",
+    "umap-learn>=0.5.4",  # Python 3.11+ requires updated llvmlite
     "sktime",
     "catboost",
     "optuna",
@@ -620,7 +620,7 @@ all = [
     # ml
     "scikit-image",
     "imbalanced-learn",
-    "umap-learn",
+    "umap-learn>=0.5.4",  # Python 3.11+ requires updated llvmlite
     "sktime",
     "catboost",
     "opencv-python",

--- a/src/scitex/__version__.py
+++ b/src/scitex/__version__.py
@@ -8,6 +8,6 @@ __FILE__ = "./src/scitex/__version__.py"
 __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
-__version__ = "2.10.1"
+__version__ = "2.10.2"
 
 # EOF


### PR DESCRIPTION
## Summary
- Pin `umap-learn>=0.5.4` to fix Python 3.11+ compatibility (llvmlite issue)
- Bump version to 2.10.2

## Problem
Docker builds failed with:
```
RuntimeError: Cannot install on Python version 3.11.13; only versions >=3.6,<3.10 are supported.
```

Dependency chain: `scitex[all]` → `umap-learn` → `pynndescent` → `llvmlite==0.36.0`

## Solution
Pin `umap-learn>=0.5.4` which uses updated `llvmlite` compatible with Python 3.11+

🤖 Generated with [Claude Code](https://claude.com/claude-code)