### PR TITLE
feat(deps): Add missing module dependencies for isolated testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ ai = [
     "xarray",
     "umap-learn",
     "sktime",
+    "markdown2",
+    "pytorch_pretrained_vit",
+    "torchvision",
+    "imbalanced-learn",
 ]
 
 # Audio Module - Text-to-Speech
@@ -132,6 +136,7 @@ benchmark = [
 # Use: pip install scitex[bridge]
 bridge = [
     "matplotlib",
+    "scipy",
 ]
 
 # Browser Module - Web automation
@@ -218,6 +223,19 @@ dsp = [
     "julius",
     "torchaudio",
     "xarray",
+    "seaborn",
+]
+
+# DevTools Module - scitex.dev code analysis and development tools
+# Use: pip install scitex[devtools]
+# Note: Named "devtools" to avoid conflict with "dev" (testing deps)
+devtools = [
+    "matplotlib",
+    "joblib",
+    "ruamel.yaml",
+    "xarray",
+    "seaborn",
+    "scipy",
 ]
 
 # DT Module - Date/time utilities
@@ -381,6 +399,8 @@ plt = [
     "scipy",
     "xarray",
     "pyyaml",
+    "joblib",
+    "ruamel.yaml",
 ]
 
 # Repro Module - Reproducibility tools
@@ -441,6 +461,8 @@ scholar = [
     "pyyaml",
     "torch",
     "tqdm",
+    "sql-manager",
+    "ruamel.yaml",
 ]
 
 # Session Module - Session management
@@ -516,6 +538,17 @@ web = [
     "joblib",
     "scikit-learn",
     "pytest-asyncio",
+    "ruamel.yaml",
+    "xarray",
+    "seaborn",
+    "scipy",
+    "torch",
+    "umap-learn",
+    "markdown2",
+    "anthropic",
+    "openai",
+    "google-genai",
+    "groq",
 ]
 
 # Writer Module - Academic paper writing

--- a/scripts/test-module.sh
+++ b/scripts/test-module.sh
@@ -35,10 +35,20 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Modules with optional extras in pyproject.toml
 MODULES_WITH_EXTRAS=(
-    ai audio benchmark browser capture cli config db decorators dsp dt fig fts gen
+    ai audio benchmark bridge browser capture cli cloud config db decorators dev dsp dt fig fts gen
     git io linalg msword nn parallel path pd plt repro resource scholar stats str
     torch types utils web writer
 )
+
+# Map module names to extras names (for naming conflicts)
+# e.g., "dev" module uses "devtools" extras (since "dev" is for pytest tools)
+get_extras_name() {
+    local module="$1"
+    case "$module" in
+    dev) echo "devtools" ;;
+    *) echo "$module" ;;
+    esac
+}
 
 # Check if module has extras
 has_extras() {
@@ -53,17 +63,19 @@ has_extras() {
 get_install_cmd() {
     local mode="$1"
     local module="$2"
+    local extras_name
+    extras_name=$(get_extras_name "$module")
 
     if [[ "$mode" == "editable" ]]; then
         if has_extras "$module"; then
-            echo "-e .[${module}]"
+            echo "-e .[${extras_name}]"
         else
             echo "-e ."
         fi
     else
         # PyPI mode
         if has_extras "$module"; then
-            echo "scitex[${module}]"
+            echo "scitex[${extras_name}]"
         else
             echo "scitex"
         fi


### PR DESCRIPTION
## Summary
- Add missing dependencies to module extras in pyproject.toml for isolated testing
- Add `devtools` extras for scitex.dev module (naming conflict with `dev` pytest tools)
- Update scripts/test-module.sh with module-to-extras mapping

## Changes

### pyproject.toml
| Module | Dependencies Added |
|--------|-------------------|
| ai | markdown2, pytorch_pretrained_vit, torchvision, imbalanced-learn |
| dsp | seaborn |
| bridge | scipy |
| plt | joblib, ruamel.yaml |
| scholar | sql-manager, ruamel.yaml |
| web | ruamel.yaml, xarray, seaborn, scipy, torch, umap-learn, markdown2, anthropic, openai, google-genai, groq |
| **devtools** (NEW) | matplotlib, joblib, ruamel.yaml, xarray, seaborn, scipy |

### scripts/test-module.sh
- Added `bridge`, `cloud`, `dev` to MODULES_WITH_EXTRAS
- Added `get_extras_name()` function for module-to-extras mapping
- Maps `dev` module to `devtools` extras (naming conflict resolution)

## Test Results
After changes:
- **PASSED**: 36 modules
- **FAILED**: 10 modules (test/impl issues, NOT dependency issues)
- **N/A**: ~10 modules (no tests)

## Test plan
- [x] Run `make test-isolated MODULE=ai` - 309 passed
- [x] Run `make test-isolated MODULE=dev` - 76 passed
- [x] Run `make test-isolated MODULE=web` - 79 passed
- [x] Run `make test-isolated MODULE=scholar` - 170 passed
- [x] Verify no import errors in test outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)