### PR TITLE
feat(social): Add CLI wrapper and MCP tools for socialia

### DIFF
--- a/src/scitex/_mcp_tools/__init__.py
+++ b/src/scitex/_mcp_tools/__init__.py
@@ -12,6 +12,7 @@ from .diagram import register_diagram_tools
 from .introspect import register_introspect_tools
 from .plt import register_plt_tools
 from .scholar import register_scholar_tools
+from .social import register_social_tools
 from .stats import register_stats_tools
 from .template import register_template_tools
 from .ui import register_ui_tools
@@ -29,6 +30,7 @@ def register_all_tools(mcp) -> None:
     register_introspect_tools(mcp)
     register_plt_tools(mcp)
     register_scholar_tools(mcp)
+    register_social_tools(mcp)
     register_stats_tools(mcp)
     register_template_tools(mcp)
     register_ui_tools(mcp)

--- a/src/scitex/_mcp_tools/social.py
+++ b/src/scitex/_mcp_tools/social.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Timestamp: 2026-01-22
+# File: /home/ywatanabe/proj/scitex-code/src/scitex/_mcp_tools/social.py
+
+"""Social media module tools for FastMCP unified server.
+
+All MCP tools delegate to socialia CLI for reproducibility.
+Each tool returns the CLI command used, enabling human reproduction.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Optional
+
+
+def _json(data: dict) -> str:
+    return json.dumps(data, indent=2, default=str)
+
+
+def _run_socialia_cli(*args: str) -> dict:
+    """Run socialia CLI and return structured result."""
+    cmd = [sys.executable, "-m", "socialia", "--json", *args]
+    cli_command = f"socialia {' '.join(args)}"
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+        if result.returncode == 0:
+            try:
+                data = json.loads(result.stdout)
+                data["cli_command"] = cli_command
+                return data
+            except json.JSONDecodeError:
+                return {
+                    "success": True,
+                    "output": result.stdout,
+                    "cli_command": cli_command,
+                }
+        else:
+            return {
+                "success": False,
+                "error": result.stderr or result.stdout,
+                "cli_command": cli_command,
+            }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": "Command timed out",
+            "cli_command": cli_command,
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "cli_command": cli_command,
+        }
+
+
+def register_social_tools(mcp) -> None:
+    """Register social media tools with FastMCP server."""
+
+    @mcp.tool()
+    async def social_post(
+        platform: str,
+        text: str,
+        reply_to: Optional[str] = None,
+        quote: Optional[str] = None,
+        subreddit: Optional[str] = None,
+        title: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> str:
+        """[social] Post content to a social media platform (twitter, linkedin, reddit, youtube)."""
+        args = ["post", platform, text]
+
+        if reply_to:
+            args.extend(["--reply-to", reply_to])
+        if quote:
+            args.extend(["--quote", quote])
+        if subreddit and platform == "reddit":
+            args.extend(["--subreddit", subreddit])
+        if title:
+            args.extend(["--title", title])
+        if dry_run:
+            args.append("--dry-run")
+
+        result = _run_socialia_cli(*args)
+        return _json(result)
+
+    @mcp.tool()
+    async def social_delete(
+        platform: str,
+        post_id: str,
+    ) -> str:
+        """[social] Delete a post from a platform (twitter, linkedin, reddit)."""
+        result = _run_socialia_cli("delete", platform, post_id)
+        return _json(result)
+
+    @mcp.tool()
+    async def social_status() -> str:
+        """[social] Check social media configuration and authentication status."""
+        result = _run_socialia_cli("status")
+        return _json(result)
+
+    @mcp.tool()
+    async def social_analytics(
+        platform: str,
+        days: int = 7,
+    ) -> str:
+        """[social] Get analytics for a platform (twitter, youtube, ga)."""
+        result = _run_socialia_cli("analytics", platform, "--days", str(days))
+        return _json(result)
+
+    @mcp.tool()
+    async def social_thread(
+        platform: str,
+        posts: list[str],
+        delay: int = 2,
+        dry_run: bool = False,
+    ) -> str:
+        """[social] Post a thread of connected posts. Posts are list of strings."""
+        import tempfile
+        from pathlib import Path
+
+        # Write posts to temp file (socialia expects file input)
+        thread_content = "\n---\n".join(posts)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(thread_content)
+            temp_path = f.name
+
+        try:
+            args = ["thread", platform, "--file", temp_path, "--delay", str(delay)]
+            if dry_run:
+                args.append("--dry-run")
+            result = _run_socialia_cli(*args)
+            result["thread_posts"] = posts
+            return _json(result)
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    @mcp.tool()
+    async def social_check_availability() -> str:
+        """[social] Check if socialia is installed and list available platforms."""
+        try:
+            from scitex.social import (
+                SOCIALIA_AVAILABLE,
+                __socialia_version__,
+            )
+
+            if SOCIALIA_AVAILABLE:
+                return _json(
+                    {
+                        "available": True,
+                        "version": __socialia_version__,
+                        "platforms": ["twitter", "linkedin", "reddit", "youtube"],
+                        "analytics": ["twitter", "youtube", "ga"],
+                    }
+                )
+            else:
+                return _json(
+                    {
+                        "available": False,
+                        "error": "socialia not installed",
+                        "install_command": "pip install socialia",
+                    }
+                )
+        except Exception as e:
+            return _json(
+                {
+                    "available": False,
+                    "error": str(e),
+                }
+            )
+
+
+# EOF

--- a/src/scitex/cli/main.py
+++ b/src/scitex/cli/main.py
@@ -21,6 +21,7 @@ from . import (
     resource,
     scholar,
     security,
+    social,
     stats,
     template,
     tex,
@@ -74,6 +75,7 @@ cli.add_command(repro.repro)
 cli.add_command(resource.resource)
 cli.add_command(scholar.scholar)
 cli.add_command(security.security)
+cli.add_command(social.social)
 cli.add_command(stats.stats)
 cli.add_command(template.template)
 cli.add_command(tex.tex)

--- a/src/scitex/cli/social.py
+++ b/src/scitex/cli/social.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# Timestamp: 2026-01-22
+# File: /home/ywatanabe/proj/scitex-code/src/scitex/cli/social.py
+
+"""
+SciTeX CLI - Social Media Commands
+
+Thin wrapper around socialia CLI with SCITEX_ environment variable prefix.
+All commands delegate to socialia for reproducibility.
+"""
+
+import subprocess
+import sys
+
+import click
+
+
+def _run_socialia(*args, json_output: bool = False) -> int:
+    """Run socialia CLI command."""
+    cmd = [sys.executable, "-m", "socialia"]
+    if json_output:
+        cmd.append("--json")
+    cmd.extend(args)
+
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def _check_socialia() -> bool:
+    """Check if socialia is available."""
+    try:
+        import socialia  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
+@click.option("--help-recursive", is_flag=True, help="Show help for all subcommands")
+@click.pass_context
+def social(ctx, help_recursive):
+    """
+    Social media management (powered by socialia)
+
+    \b
+    Platforms:
+      twitter   - Twitter/X posting and management
+      linkedin  - LinkedIn posting
+      reddit    - Reddit posting
+      youtube   - YouTube video uploads
+
+    \b
+    Examples:
+      scitex social post twitter "Hello from SciTeX!"
+      scitex social post linkedin "Research update"
+      scitex social status
+      scitex social analytics twitter
+
+    \b
+    Environment Variables (SCITEX_ prefix):
+      SCITEX_X_CONSUMER_KEY          Twitter API keys
+      SCITEX_LINKEDIN_ACCESS_TOKEN   LinkedIn OAuth token
+      SCITEX_REDDIT_CLIENT_ID        Reddit app credentials
+      SCITEX_YOUTUBE_API_KEY         YouTube API key
+
+    Note: Falls back to SOCIALIA_ prefix if SCITEX_ not set.
+    """
+    if not _check_socialia():
+        click.secho("Error: socialia not installed", fg="red", err=True)
+        click.echo("\nInstall with: pip install socialia")
+        ctx.exit(1)
+
+    if help_recursive:
+        from . import print_help_recursive
+
+        print_help_recursive(ctx, social)
+        ctx.exit(0)
+    elif ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@social.command()
+@click.argument(
+    "platform", type=click.Choice(["twitter", "linkedin", "reddit", "youtube"])
+)
+@click.argument("text", required=False)
+@click.option(
+    "-f", "--file", type=click.Path(exists=True), help="Read content from file"
+)
+@click.option("--reply-to", help="Post ID to reply to (Twitter)")
+@click.option("--quote", help="Post ID to quote (Twitter)")
+@click.option("-s", "--subreddit", default="test", help="Target subreddit (Reddit)")
+@click.option("-t", "--title", help="Post title (Reddit/YouTube)")
+@click.option("--dry-run", is_flag=True, help="Preview without posting")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def post(platform, text, file, reply_to, quote, subreddit, title, dry_run, as_json):
+    """
+    Post content to a social platform
+
+    \b
+    Examples:
+      scitex social post twitter "Hello world!"
+      scitex social post twitter --file tweet.txt
+      scitex social post reddit "Check this out" -s python -t "Cool project"
+      scitex social post linkedin "Professional update"
+      scitex social post twitter "Test" --dry-run
+    """
+    args = ["post", platform]
+
+    if text:
+        args.append(text)
+    if file:
+        args.extend(["--file", file])
+    if reply_to:
+        args.extend(["--reply-to", reply_to])
+    if quote:
+        args.extend(["--quote", quote])
+    if subreddit and platform == "reddit":
+        args.extend(["--subreddit", subreddit])
+    if title:
+        args.extend(["--title", title])
+    if dry_run:
+        args.append("--dry-run")
+
+    sys.exit(_run_socialia(*args, json_output=as_json))
+
+
+@social.command()
+@click.argument("platform", type=click.Choice(["twitter", "linkedin", "reddit"]))
+@click.argument("post_id")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def delete(platform, post_id, as_json):
+    """
+    Delete a post from a platform
+
+    \b
+    Examples:
+      scitex social delete twitter 1234567890
+      scitex social delete reddit abc123
+    """
+    sys.exit(_run_socialia("delete", platform, post_id, json_output=as_json))
+
+
+@social.command()
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def status(as_json):
+    """
+    Check configuration and authentication status
+
+    \b
+    Example:
+      scitex social status
+      scitex social status --json
+    """
+    sys.exit(_run_socialia("status", json_output=as_json))
+
+
+@social.command()
+@click.argument("platform", type=click.Choice(["twitter", "youtube", "ga"]))
+@click.option("--days", "-d", type=int, default=7, help="Number of days to analyze")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def analytics(platform, days, as_json):
+    """
+    Get analytics for a platform
+
+    \b
+    Platforms:
+      twitter  - Tweet engagement metrics
+      youtube  - Channel and video statistics
+      ga       - Google Analytics reports
+
+    \b
+    Examples:
+      scitex social analytics twitter
+      scitex social analytics youtube --days 30
+      scitex social analytics ga --json
+    """
+    args = ["analytics", platform, "--days", str(days)]
+    sys.exit(_run_socialia(*args, json_output=as_json))
+
+
+@social.command()
+@click.argument("platform", type=click.Choice(["twitter"]))
+@click.option(
+    "-f", "--file", type=click.Path(exists=True), required=True, help="Thread file"
+)
+@click.option("--delay", type=int, default=2, help="Delay between posts (seconds)")
+@click.option("--dry-run", is_flag=True, help="Preview without posting")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def thread(platform, file, delay, dry_run, as_json):
+    """
+    Post a thread (multiple connected posts)
+
+    \b
+    Thread file format (--- separates posts):
+      First tweet in the thread
+      ---
+      Second tweet, replying to first
+      ---
+      Third tweet, and so on...
+
+    \b
+    Example:
+      scitex social thread twitter --file thread.txt
+      scitex social thread twitter --file thread.txt --dry-run
+    """
+    args = ["thread", platform, "--file", file, "--delay", str(delay)]
+    if dry_run:
+        args.append("--dry-run")
+    sys.exit(_run_socialia(*args, json_output=as_json))
+
+
+@social.command()
+@click.option(
+    "-t",
+    "--transport",
+    type=click.Choice(["stdio", "sse", "http"]),
+    default="stdio",
+    help="Transport protocol",
+)
+@click.option("--host", default="0.0.0.0", help="Host for HTTP/SSE transport")
+@click.option("--port", default=8086, type=int, help="Port for HTTP/SSE transport")
+def serve(transport, host, port):
+    """
+    Run socialia MCP server
+
+    \b
+    Examples:
+      scitex social serve                    # stdio for Claude Desktop
+      scitex social serve -t http --port 8086
+    """
+    args = ["mcp", "run", "--transport", transport]
+    if transport != "stdio":
+        args.extend(["--host", host, "--port", str(port)])
+        click.secho(f"Starting socialia MCP server ({transport})", fg="cyan")
+        click.echo(f"  Host: {host}")
+        click.echo(f"  Port: {port}")
+
+    sys.exit(_run_socialia(*args))
+
+
+if __name__ == "__main__":
+    social()
+
+# EOF


### PR DESCRIPTION
## Summary
- Adds CLI wrapper for `scitex social` subcommand delegating to socialia CLI
- Adds 6 MCP tools for social media integration
- Completes the socialia integration (Python API was added in #111)

## CLI Commands Added
| Command | Description |
|---------|-------------|
| `scitex social post` | Post to twitter, linkedin, reddit, youtube |
| `scitex social delete` | Delete posts from platforms |
| `scitex social status` | Check authentication status |
| `scitex social analytics` | Get platform analytics |
| `scitex social thread` | Post connected thread of posts |
| `scitex social serve` | Run socialia MCP server |

## MCP Tools Added
- `social_post` - Post content to platforms
- `social_delete` - Delete a post
- `social_status` - Check configuration status
- `social_analytics` - Get analytics data
- `social_thread` - Post connected thread
- `social_check_availability` - Check if socialia is installed

## Test plan
- [x] CLI help works: `scitex social --help`
- [x] MCP tools import correctly
- [x] All tools registered in FastMCP server

Closes: Part of #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)