### PR TITLE
feat(social): Add v0.1.4 CRUD commands (check, feed, me)

### DIFF
--- a/src/scitex/_mcp_tools/social.py
+++ b/src/scitex/_mcp_tools/social.py
@@ -174,5 +174,40 @@ def register_social_tools(mcp) -> None:
                 }
             )
 
+    @mcp.tool()
+    async def social_check(
+        platform: Optional[str] = None,
+    ) -> str:
+        """[social] Check platform connection status (v0.1.4+)."""
+        args = ["check"]
+        if platform:
+            args.append(platform)
+        result = _run_socialia_cli(*args)
+        return _json(result)
+
+    @mcp.tool()
+    async def social_feed(
+        platform: Optional[str] = None,
+        limit: int = 10,
+        mentions: bool = False,
+    ) -> str:
+        """[social] Get recent posts from platform feeds (v0.1.4+)."""
+        args = ["feed"]
+        if platform:
+            args.append(platform)
+        args.extend(["--limit", str(limit)])
+        if mentions:
+            args.append("--mentions")
+        result = _run_socialia_cli(*args)
+        return _json(result)
+
+    @mcp.tool()
+    async def social_me(
+        platform: str,
+    ) -> str:
+        """[social] Get user profile information (v0.1.4+)."""
+        result = _run_socialia_cli("me", platform)
+        return _json(result)
+
 
 # EOF

--- a/src/scitex/cli/social.py
+++ b/src/scitex/cli/social.py
@@ -160,6 +160,71 @@ def status(as_json):
 
 
 @social.command()
+@click.argument(
+    "platform",
+    type=click.Choice(["twitter", "linkedin", "reddit", "youtube"]),
+    required=False,
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def check(platform, as_json):
+    """
+    Check platform connection status.
+
+    \b
+    Examples:
+      scitex social check              # Check all platforms
+      scitex social check twitter      # Check specific platform
+    """
+    args = ["check"]
+    if platform:
+        args.append(platform)
+    sys.exit(_run_socialia(*args, json_output=as_json))
+
+
+@social.command()
+@click.argument(
+    "platform",
+    type=click.Choice(["twitter", "linkedin", "reddit"]),
+    required=False,
+)
+@click.option("--limit", "-l", type=int, default=10, help="Number of posts to fetch")
+@click.option("--mentions", is_flag=True, help="Get mentions/notifications instead")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def feed(platform, limit, mentions, as_json):
+    """
+    Get recent posts from platform feeds.
+
+    \b
+    Examples:
+      scitex social feed                    # All platforms
+      scitex social feed twitter --limit 5  # Specific platform
+      scitex social feed --mentions         # Get mentions
+    """
+    args = ["feed"]
+    if platform:
+        args.append(platform)
+    args.extend(["--limit", str(limit)])
+    if mentions:
+        args.append("--mentions")
+    sys.exit(_run_socialia(*args, json_output=as_json))
+
+
+@social.command()
+@click.argument("platform", type=click.Choice(["twitter", "linkedin", "reddit"]))
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def me(platform, as_json):
+    """
+    Get user profile information.
+
+    \b
+    Examples:
+      scitex social me twitter
+      scitex social me linkedin --json
+    """
+    sys.exit(_run_socialia("me", platform, json_output=as_json))
+
+
+@social.command()
 @click.argument("platform", type=click.Choice(["twitter", "youtube", "ga"]))
 @click.option("--days", "-d", type=int, default=7, help="Number of days to analyze")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")


### PR DESCRIPTION
## Summary
- Adds socialia v0.1.4 CRUD commands to CLI and MCP tools
- Enables reading feeds, checking connections, and getting user profiles

## New CLI Commands
| Command | Description |
|---------|-------------|
| `scitex social check [platform]` | Check platform connection status |
| `scitex social feed [platform]` | Get recent posts from feeds |
| `scitex social me <platform>` | Get user profile information |

## New MCP Tools
- `social_check` - Check platform connections
- `social_feed` - Get feed posts with limit/mentions options
- `social_me` - Get user profile info

## Requirements
- socialia>=0.1.4

## Test plan
- [x] CLI help shows new commands
- [x] MCP tools registered (9 total)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)