### PR TITLE
fix(rtd): Add deps and mock imports for autodoc

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -43,7 +43,7 @@ autodoc_default_options = {
     "exclude-members": "__weakref__,__init__,__dict__,__module__",
 }
 
-# Mock imports for packages with system dependencies that can't be installed on RTD
+# Mock imports for packages that can't install on RTD (system deps, heavy ML, etc.)
 autodoc_mock_imports = [
     # GUI frameworks (require display)
     "PyQt6",
@@ -54,9 +54,33 @@ autodoc_mock_imports = [
     "sounddevice",
     # System-level dependencies
     "cv2",  # OpenCV requires system libs
-    # Optional dependencies that may not be installed
-    "figrecipe",
-    "figrecipe._graph_presets",
+    # Heavy ML/AI packages
+    "torch",
+    "torchvision",
+    "pytorch_pretrained_vit",
+    # LLM API clients (not needed for docs)
+    "openai",
+    "anthropic",
+    "google",
+    "google.genai",
+    "groq",
+    # Optional heavy packages
+    "umap",
+    "sktime",
+    "imbalanced_learn",
+    "imblearn",
+    "xarray",
+    # Audio/browser packages
+    "pyttsx3",
+    "gTTS",
+    "gtts",
+    "pydub",
+    "elevenlabs",
+    "playwright",
+    "mss",
+    "aiohttp",
+    # Cloud package
+    "scitex_cloud",
 ]
 
 # Autosummary settings

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -5,6 +5,24 @@ sphinx-copybutton>=0.5
 sphinx-autodoc-typehints>=1.25
 nbsphinx>=0.9
 
+# Core scientific deps (installable on RTD)
+matplotlib
+scipy
+numpy
+pandas
+scikit-learn
+seaborn
+pillow
+pyyaml
+requests
+natsort
+ruamel.yaml
+joblib
+
 # Thin wrapper dependencies (for autodoc)
 scitex-writer>=2.0
 socialia>=0.3.0
+figrecipe
+crossref-local
+openalex-local
+scitex-linter


### PR DESCRIPTION
## Summary
- Added core scientific packages (matplotlib, scipy, etc.) to RTD requirements.txt
- Mock only truly un-installable packages (GUI, audio, torch, LLM APIs)
- Fixes `ImportError: scitex.ai requires additional dependencies` crash

## Test plan
- [ ] RTD build passes on main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)