### PR TITLE
fix(rtd): Remove openalex-local dep causing pip deadlock

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -81,6 +81,8 @@ autodoc_mock_imports = [
     "aiohttp",
     # Cloud package
     "scitex_cloud",
+    # OpenAlex (pulls awscli causing pip deadlock)
+    "openalex_local",
 ]
 
 # Autosummary settings

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -46,5 +46,5 @@ scitex-writer>=2.0
 socialia>=0.3.0
 figrecipe
 crossref-local
-openalex-local
+# openalex-local  # Excluded: pulls awscli which causes pip resolver deadlock
 scitex-linter


### PR DESCRIPTION
## Summary
- Removed openalex-local from RTD requirements (pulls awscli → pip resolver deadlock)
- Added openalex_local to autodoc_mock_imports instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)