### PR TITLE
fix(rtd): Handle dunder attrs in LazyModule to prevent autodoc crash

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -56,6 +56,22 @@ class _LazyModule:
         )
 
     def __getattr__(self, attr):
+        # Return sensible defaults for dunder attrs without triggering import
+        # (prevents Sphinx autodoc crashes when optional deps are missing)
+        if attr == "__name__":
+            return f"scitex.{self._name}"
+        if attr == "__module__":
+            return "scitex"
+        if attr == "__qualname__":
+            return self._name
+        if attr == "__path__":
+            return []
+        if attr == "__file__":
+            return None
+        if attr == "__loader__":
+            return None
+        if attr == "__spec__":
+            return None
         try:
             return getattr(self._load_module(), attr)
         except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
## Summary
- Modified `_LazyModule.__getattr__` to return sensible defaults for `__name__`, `__module__`, `__path__`, etc. without triggering the actual module import
- This prevents Sphinx autodoc from crashing when optional dependencies are missing on RTD
- Root cause fix — eliminates the whack-a-mole of adding individual deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)