### PR TITLE
chore(dev): add scitex-tunnel to ecosystem registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -800,6 +800,9 @@ dev = [
     "tomlkit",
     "matplotlib",
     "pyyaml",
+    # SciTeX ecosystem packages
+    "scitex-tunnel",
+    "scitex-container",
 ]
 
 # All features (everything except dev)

--- a/src/scitex/_dev/_ecosystem.py
+++ b/src/scitex/_dev/_ecosystem.py
@@ -103,6 +103,12 @@ ECOSYSTEM: Dict[str, PackageInfo] = {
         "github_repo": "ywatanabe1989/scitex-container",
         "import_name": "scitex_container",
     },
+    "scitex-tunnel": {
+        "local_path": "~/proj/scitex-tunnel",
+        "pypi_name": "scitex-tunnel",
+        "github_repo": "ywatanabe1989/scitex-tunnel",
+        "import_name": "scitex_tunnel",
+    },
     "singularity-template": {
         "local_path": "~/proj/singularity-template",
         "pypi_name": "singularity-template",


### PR DESCRIPTION
## Summary
- Add scitex-tunnel + scitex-container to `[dev]` optional dependencies
- Register scitex-tunnel in `_ecosystem.py` for versions dashboard

## Test plan
- [x] `scitex dev versions list` shows scitex-tunnel
- [x] Both packages appear in dev extras

🤖 Generated with [Claude Code](https://claude.com/claude-code)