### PR TITLE
fix: add scitex-io, scitex-stats to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ dependencies = [
     "natsort",  # Natural sorting - used by many modules
     # Reproducibility Verification
     "scitex-clew>=0.1.0",
+    # Delegated core modules (thin re-exports)
+    "scitex-io>=0.2.0",
+    "scitex-stats>=0.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Add scitex-io and scitex-stats to core dependencies (were optional but imported unconditionally)
- Fixes RTD build failure: `ModuleNotFoundError: No module named 'scitex_io'`
- Fix dashboard to show Spartan host badge dynamically

## Test plan
- [x] RTD build should pass after merge