### PR TITLE
feat: add CLA and contributor workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,33 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "signatures/cla.json"
+          path-to-document: "https://github.com/ywatanabe1989/scitex-python/blob/main/CLA.md"
+          branch: "main"
+          allowlist: bot*
+          message-success: |
+            Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
+          message-commit-not-allowed: |
+            Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/scitex-python/blob/main/CLA.md) before your contribution can be merged.
+            Comment `I have read and agree to the SciTeX CLA.` to sign.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,77 @@
+# SciTeX Contributor License Agreement (CLA)
+
+Version 1.0 — Effective 2026-03-12
+
+## Purpose
+
+SciTeX is licensed under AGPL-3.0 and follows a dual-licensing model:
+
+- **Researchers and individuals**: Free forever under AGPL-3.0.
+- **Enterprises and institutions**: Commercial license available upon request.
+
+To maintain the ability to offer dual licensing and ensure the long-term
+sustainability of the project, we ask contributors to sign this CLA before
+their first contribution is merged.
+
+## Agreement
+
+By submitting a pull request or other contribution to any SciTeX repository,
+you agree to the following terms:
+
+### 1. You retain copyright
+
+You retain full copyright ownership of your contributions.
+
+### 2. You grant a broad license to the project
+
+You grant Yusuke Watanabe, and any successor entity operating the SciTeX
+project (the "Project Lead"), a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable license to:
+
+- Use, reproduce, modify, and distribute your contributions.
+- Sublicense your contributions under alternative licenses, including
+  dual-licensing for institutional and commercial use, for the purpose of
+  sustaining the SciTeX project.
+
+### 3. You confirm originality
+
+You confirm that:
+
+- Your contributions are your original work.
+- You have the legal right to grant the above license.
+- Your contributions do not infringe on third-party rights.
+
+If any portion is based on existing work, you have disclosed the source and
+confirmed its license is compatible with AGPL-3.0.
+
+### 4. No obligation
+
+This agreement does not create any obligation for the Project Lead to use,
+merge, or maintain your contributions.
+
+## How to sign
+
+When you open your first pull request, the CLA Assistant bot will ask you to
+sign electronically. This is a one-time process per contributor.
+
+Alternatively, you may sign by adding the following statement to your pull
+request description:
+
+> I have read and agree to the [SciTeX CLA](CLA.md).
+
+## Why a CLA?
+
+SciTeX aims to be free for researchers forever. A CLA ensures the project can:
+
+- Offer institutional/campus licenses to universities and companies.
+- Change licenses if needed to protect the community (e.g., against
+  proprietary forks).
+- Provide legal clarity for institutions adopting SciTeX.
+
+This is the same approach used by MongoDB, Elasticsearch, and many other
+successful open-source projects with dual-licensing models.
+
+## Questions
+
+If you have questions about this CLA, please open an issue or contact
+ywatanabe@scitex.ai.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to SciTeX
+
+Thank you for your interest in contributing to SciTeX. This guide covers the
+process for reporting issues, suggesting features, and submitting code.
+
+## Contributor License Agreement
+
+Before your first contribution can be merged, you must agree to the
+[SciTeX CLA](CLA.md). This is a one-time process. The CLA ensures that:
+
+- You retain copyright of your work.
+- The project can continue to offer dual licensing (free for researchers,
+  commercial for enterprises).
+
+See [CLA.md](CLA.md) for full details.
+
+## Reporting Issues
+
+- Search [existing issues](https://github.com/ywatanabe1989/scitex-python/issues)
+  before opening a new one.
+- Include a minimal reproducible example when reporting bugs.
+- Specify your Python version, OS, and `scitex` version.
+
+## Development Setup
+
+```bash
+git clone git@github.com:ywatanabe1989/scitex-python.git
+cd scitex-python
+pip install -e ".[dev]"
+```
+
+## Branch Workflow
+
+- `main` — stable releases only. Do not push directly.
+- `develop` — integration branch. PRs target here.
+- Feature branches — create from `develop`, name as `feature/<description>`.
+
+```bash
+git checkout develop
+git checkout -b feature/my-change
+# ... make changes ...
+git push origin feature/my-change
+# Open PR targeting develop
+```
+
+## Code Style
+
+- Follow existing conventions in the codebase.
+- Use `_` prefix for internal/private modules and functions.
+- Keep files under 512 lines.
+- Run tests before submitting:
+
+```bash
+pytest tests/ -x -q
+```
+
+## Pull Request Process
+
+1. Ensure your branch is up to date with `develop`.
+2. Write tests for new functionality.
+3. Run the test suite and confirm all tests pass.
+4. Open a PR targeting `develop` with a clear description.
+5. The CLA bot will check your CLA status on your first PR.
+
+## License
+
+By contributing, you agree to the terms of the [CLA](CLA.md), which includes
+licensing under AGPL-3.0 (see [LICENSE](LICENSE)) and the dual-licensing
+provisions described therein.


### PR DESCRIPTION
## Summary
- Add CLA.md (dual-licensing agreement for SciTeX)
- Add CONTRIBUTING.md (contributor guide)
- Add CLA Assistant GitHub Action (auto-sign on PRs)

## Test plan
- [x] CLA.md reviewed for legal clarity
- [x] CONTRIBUTING.md links to CLA correctly
- [x] PERSONAL_ACCESS_TOKEN secret configured
- [x] Workflow syntax validated