### PR TITLE
fix(pyproject): remove obsolete scitex-ui and scitex-plt entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,11 @@ scitex = "scitex.__main__:main"
 scitex-canvas = "scitex.canvas.mcp_server:main"
 scitex-capture = "scitex.capture.mcp_server:main"
 scitex-diagram = "scitex.diagram.mcp_server:main"
-scitex-plt = "scitex.plt.mcp_server:main"
+# scitex-plt entry point now in standalone scitex-plt package
 scitex-scholar = "scitex.scholar.mcp_server:main"
 # scitex-stats entry point now in standalone scitex-stats package
 scitex-template = "scitex.template.mcp_server:main"
-scitex-ui = "scitex.ui.mcp_server:main"
+# scitex-ui entry point now in standalone scitex-ui package
 # Unified MCP Server (all modules in one)
 scitex-mcp-server = "scitex.mcp_server:main"
 


### PR DESCRIPTION
## Summary
- `scitex-ui` and `scitex-plt` were extracted into standalone packages; the submodules `scitex/ui/mcp_server.py` and `scitex/plt/mcp_server.py` no longer exist in scitex-python
- The corresponding `[project.scripts]` entry points still pointed at them, so pip's entry-point collision made `scitex-ui` (and `scitex-plt`) resolve to the broken path
- Reproduction: `scitex-ui --help` → `ModuleNotFoundError: No module named 'scitex.ui.mcp_server'`
- Mirrors the earlier clean-up done for `scitex-audio` and `scitex-stats`

## Test plan
- [x] `pip install -e .` on scitex-python, then `pip install -e .` on scitex-ui
- [x] `scitex-ui --help` now prints click help from `scitex_ui._cli:main`
- [ ] CI passes

Closes ywatanabe1989/todo#184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)