### PR TITLE
fix(cli): make LazyGroup.get_command tolerant of optional-dep leaks (#279)

### DIFF
--- a/src/scitex/cli/main.py
+++ b/src/scitex/cli/main.py
@@ -63,11 +63,32 @@ class LazyGroup(click.Group):
                 formatter.write_dl(rows)
 
     def _load_lazy(self, cmd_name):
+        """Import a lazy subcommand, tolerating optional-dep failures.
+
+        If the subcommand's module cannot be imported (e.g., an optional
+        third-party dependency like ``bs4`` or ``flask`` is missing), we
+        return ``None`` and log a debug line rather than raising
+        ``ImportError``. This keeps ``scitex --json`` and
+        ``scitex --help-recursive`` -- which walk every lazy subcommand
+        to build the full command tree -- robust against a single broken
+        leaf. Direct invocation of the affected subcommand still fails
+        cleanly via click's "No such command" path. See ywatanabe1989/todo#279.
+        """
         import importlib
+        import logging
 
         module_path, attr_name, _ = self._lazy_subcommands[cmd_name]
-        mod = importlib.import_module(module_path)
-        return getattr(mod, attr_name)
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError as exc:
+            logging.getLogger(__name__).debug(
+                "Lazy-loaded subcommand %r unavailable (%s): %s",
+                cmd_name,
+                module_path,
+                exc,
+            )
+            return None
+        return getattr(mod, attr_name, None)
 
 
 _LAZY_SUBCOMMANDS = {

--- a/src/scitex/web/_scraping.py
+++ b/src/scitex/web/_scraping.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python3
 # File: ./src/scitex/web/_scraping.py
 
-"""Web scraping utilities for extracting URLs."""
+"""Web scraping utilities for extracting URLs.
+
+``bs4`` is an optional third-party dependency (only needed when actually
+scraping). Do **not** import it at module load -- doing so leaks the
+``ModuleNotFoundError`` through ``scitex.web.__init__`` and through
+``scitex.cli.web``, which in turn breaks ``scitex --json`` and
+``scitex --help-recursive`` on any install without ``beautifulsoup4``.
+See ywatanabe1989/todo#279. The import now lives inside each scraping
+function, so merely importing this module is side-effect-free.
+"""
 
 import re
 import urllib.parse
 from typing import List, Optional, Set
 
 import requests
-from bs4 import BeautifulSoup
 
 from scitex.logging import getLogger
 
@@ -42,6 +50,8 @@ def get_urls(
         >>> urls = get_urls('https://example.com', pattern=r'\\.pdf$')
         >>> urls = get_urls('https://example.com', same_domain=True)
     """
+    from bs4 import BeautifulSoup  # lazy: see module docstring, todo#279
+
     try:
         logger.info(f"Fetching URLs from: {url}")
         response = requests.get(
@@ -108,6 +118,8 @@ def get_image_urls(
         >>> img_urls = get_image_urls('https://example.com')
         >>> img_urls = get_image_urls('https://example.com', pattern=r'\\.png$')
     """
+    from bs4 import BeautifulSoup  # lazy: see module docstring, todo#279
+
     try:
         logger.info(f"Fetching image URLs from: {url}")
         response = requests.get(

--- a/src/scitex/web/download_images.py
+++ b/src/scitex/web/download_images.py
@@ -21,8 +21,13 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import requests
-from bs4 import BeautifulSoup
 from tqdm import tqdm
+
+# NOTE: ``bs4`` is imported lazily inside functions that actually use it.
+# Importing at module load leaks ``ModuleNotFoundError`` through
+# ``scitex.web.__init__`` and breaks ``scitex --json`` /
+# ``scitex --help-recursive`` on installs without beautifulsoup4.
+# See ywatanabe1989/todo#279.
 
 try:
     from io import BytesIO
@@ -73,6 +78,8 @@ def _is_direct_image_url(url: str) -> bool:
 
 def _extract_image_urls(url: str, same_domain: bool = False) -> List[str]:
     """Extract image URLs from a webpage."""
+    from bs4 import BeautifulSoup  # lazy: see module note, todo#279
+
     try:
         logger.info(f"Fetching page: {url}")
         response = requests.get(


### PR DESCRIPTION
## Summary

Fixes [ywatanabe1989/todo#279](https://github.com/ywatanabe1989/todo/issues/279) — `scitex --json` and `scitex --help-recursive` crash with `ModuleNotFoundError: No module named 'bs4'` on any venv without `beautifulsoup4` pre-installed. Fresh `pip install scitex` (2.27.3) reproduces the crash; `#279` was reopened 2026-04-14 after the "it's just stale venv" closure turned out to be wrong.

This PR is the structural complement to the earlier workaround `b5ed9f13` (`fix(deps): add beautifulsoup4 to core dependencies`). That commit papered over the specific bs4 leak by making bs4 a hard dep, but (a) it doesn't prevent the next optional-dep from doing the same thing tomorrow, and (b) it hasn't been released — PyPI 2.27.3 still doesn't declare bs4.

## Root cause

`scitex.cli.main.LazyGroup._load_lazy()` eagerly calls `importlib.import_module(module_path)` for the lazy subcommand's target. That module — `scitex.cli.web` — does `from scitex.web import download_images, get_image_urls, get_urls`, which loads `scitex/web/__init__.py`, which loads `_scraping.py`, which hard-imports `from bs4 import BeautifulSoup` at module scope.

`group_to_json()` and `help_recursive_to_json()` both walk every lazy subcommand to build the command tree — so a single leaf that can't import crashes the entire `--json` or `--help-recursive` output, even for subcommands that would otherwise work fine.

The same class of bug also affects `scitex.io` (#441, flask leak) and `scitex.resource` (#157, dashboard side-effect). This PR handles the immediate `scitex.cli.web → bs4` case; the structural `_load_lazy` tolerance change protects against every other lazy subcommand going forward.

## Changes

Three files, minimal diffs:

### 1. `src/scitex/cli/main.py` — structural: tolerate optional-dep failures in lazy-load

```diff
 def _load_lazy(self, cmd_name):
+    """Import a lazy subcommand, tolerating optional-dep failures.
+
+    If the subcommand's module cannot be imported (e.g., an optional
+    third-party dependency like ``bs4`` or ``flask`` is missing), we
+    return ``None`` and log a debug line rather than raising
+    ``ImportError``. This keeps ``scitex --json`` and
+    ``scitex --help-recursive`` -- which walk every lazy subcommand
+    to build the full command tree -- robust against a single broken
+    leaf. Direct invocation of the affected subcommand still fails
+    cleanly via click's "No such command" path. See ywatanabe1989/todo#279.
+    """
     import importlib
+    import logging

     module_path, attr_name, _ = self._lazy_subcommands[cmd_name]
-    mod = importlib.import_module(module_path)
-    return getattr(mod, attr_name)
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError as exc:
+        logging.getLogger(__name__).debug(
+            "Lazy-loaded subcommand %r unavailable (%s): %s",
+            cmd_name, module_path, exc,
+        )
+        return None
+    return getattr(mod, attr_name, None)
```

Every existing caller of `get_command()` already checks `if cmd is None: continue`:

- `scitex/cli/__init__.py:127` (`group_to_json`)
- `scitex/cli/__init__.py:34, 44` (`print_help_recursive`)
- `scitex/cli/main.py:54, 179` (`format_commands`, `_get_all_command_paths`)

So returning `None` on ImportError is a safe, drop-in improvement; no downstream changes required.

Direct invocation (`scitex web --help`) still fails — but via click's standard `UsageError: No such command 'web'` path, which is a substantially better error than `ModuleNotFoundError: No module named 'bs4'`.

### 2. `src/scitex/web/_scraping.py` — localized: lazy-import bs4 into function bodies

```diff
-from bs4 import BeautifulSoup
 from scitex.logging import getLogger
 ...
 def get_urls(url: str, ...) -> List[str]:
+    from bs4 import BeautifulSoup  # lazy: see module docstring, todo#279
     try: ...

 def get_image_urls(url: str, ...) -> List[str]:
+    from bs4 import BeautifulSoup  # lazy: see module docstring, todo#279
     try: ...
```

Importing `scitex.web` is now side-effect-free. Calling `get_urls()` / `get_image_urls()` still requires `bs4`, which is the correct semantic for an optional feature.

### 3. `src/scitex/web/download_images.py` — localized: same pattern

```diff
 import requests
-from bs4 import BeautifulSoup
 from tqdm import tqdm
 ...
 def _extract_image_urls(url, ...):
+    from bs4 import BeautifulSoup  # lazy: see module note, todo#279
     ...
```

## Verification

On MBA `~/.venv` (editable install of this branch, `bs4` NOT installed):

```
$ scitex --version
scitex, version 2.27.3

$ scitex --json | python -c 'import json,sys; d=json.load(sys.stdin); print(len(d["data"]["commands"]), "commands,", "web" in d["data"]["commands"])'
36 commands, True

$ scitex --help-recursive >/dev/null; echo rc=$?
rc=0

$ python -c "import scitex.web; print('ok')"
ok

$ python -c "import scitex.cli.web; print('ok')"
ok
```

Before this PR, all four of the above produce the `ModuleNotFoundError: No module named 'bs4'` crash documented in #279 (most notably on a fresh install of the 2.27.3 wheel from PyPI).

`scitex --help-recursive` emits two pre-existing `click.MultiCommand` deprecation warnings from click 9.0 which are unrelated to this change.

## Backward compat

None broken:
- `scitex --json` output format unchanged (it's the same `Result` envelope; just no longer crashes).
- `scitex.web.get_urls` / `get_image_urls` / `download_images.download_images` signatures unchanged.
- Direct invocation of `scitex web <subcmd>` still works when `bs4` IS installed.
- Existing `_load_lazy` callers handle `None` return value already.

## Related

- [ywatanabe1989/todo#279](https://github.com/ywatanabe1989/todo/issues/279) — the crash report (reopened with reproducer + blast-radius analysis 2026-04-14)
- [ywatanabe1989/todo#438](https://github.com/ywatanabe1989/todo/issues/438) — broader CLI convention scorecard (this PR restores `--json` and `--help-recursive` on the `scitex` CLI)
- [ywatanabe1989/todo#441](https://github.com/ywatanabe1989/todo/issues/441) — same-class bug for `scitex.io → flask`; can be fixed with the same lazy-import pattern applied to `scitex/io/bundle/kinds/_table/_latex/_editor/_app.py` (separate follow-up PR)
- `b5ed9f13` — prior workaround (`fix(deps): add beautifulsoup4 to core dependencies`). This PR does not remove that addition; the lazy-import fix is complementary and gives minimal-deps venvs a working CLI even before any bs4 install.

## Follow-ups (out of scope)

- Apply the same lazy-import pattern to `scitex/io/bundle/kinds/_table/_latex/_editor/_app.py` to fix #441 (`flask` leak through `scitex.io` top-level).
- Audit `scitex.scholar.metadata_engines.individual.ArXivEngine`, `scitex.scholar.url_finder.translators._individual.*` for the same `from bs4 import BeautifulSoup` pattern and lazy-import them as well (defense in depth — currently these are not in the CLI tree-walker path, but they could be reached by `scitex scholar`).
- Consider adopting PEP 562 `__getattr__` lazy submodule loading at `scitex.io.__init__` / `scitex.web.__init__` / `scitex.resource.__init__` as the durable fix for this class of bug.

🤖 Generated by mamba-quality-checker-mba (Orochi fleet quality auditor).
