### PR TITLE
fix(io): lazy-import flask in LaTeX editor to unbreak scitex.io (#441)

### DIFF
--- a/src/scitex/io/bundle/kinds/_table/_latex/_editor/_app.py
+++ b/src/scitex/io/bundle/kinds/_table/_latex/_editor/_app.py
@@ -2,7 +2,22 @@
 # Timestamp: 2025-12-20
 # File: /home/ywatanabe/proj/scitex-code/src/scitex/fsb/_tables/_latex/_editor/_app.py
 
-"""Flask application for LaTeX error editor."""
+"""Flask application for LaTeX error editor.
+
+``flask`` is an optional third-party dependency used exclusively by the
+interactive LaTeX editor (``LaTeXEditor`` / ``launch_editor``). Importing
+it at module load leaks ``ModuleNotFoundError: No module named 'flask'``
+through the ``scitex.io.bundle`` eager-import chain, which in turn
+breaks the top-level public API ``import scitex.io`` on any install
+without ``flask`` -- see ywatanabe1989/todo#441.
+
+To keep ``import scitex.io`` side-effect-free, the flask import now
+lives inside ``LaTeXEditor.__init__`` (and the few methods that need
+the module-level ``request`` / ``jsonify`` names). Merely importing
+this module, ``scitex.io``, or any parent package no longer requires
+``flask``; only constructing a ``LaTeXEditor`` or calling
+``launch_editor`` does.
+"""
 
 import json
 import socket
@@ -11,8 +26,6 @@ import tempfile
 import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-
-from flask import Flask, jsonify, render_template_string, request
 
 from .._validator import ValidationResult, validate_latex
 
@@ -477,6 +490,10 @@ class LaTeXEditor:
             bundle: Associated FTS bundle
             output_path: Where to save edits
         """
+        # Lazy flask import so ``import scitex.io`` does not require
+        # flask. See module docstring and ywatanabe1989/todo#441.
+        from flask import Flask  # noqa: PLC0415
+
         self.latex_code = latex_code
         self.bundle = bundle
         self.output_path = output_path
@@ -487,6 +504,13 @@ class LaTeXEditor:
 
     def _setup_routes(self) -> None:
         """Setup Flask routes."""
+        # Lazy flask imports so ``import scitex.io`` does not require
+        # flask. See module docstring and ywatanabe1989/todo#441.
+        from flask import (  # noqa: PLC0415
+            jsonify,
+            render_template_string,
+            request,
+        )
 
         @self.app.route("/")
         def index():


### PR DESCRIPTION
## Summary

Fixes [ywatanabe1989/todo#441](https://github.com/ywatanabe1989/todo/issues/441) — `import scitex.io` crashes with `ModuleNotFoundError: No module named 'flask'` on any venv without `flask` pre-installed, because `scitex.io.bundle.kinds._table._latex._editor._app` does a top-level `from flask import ...` at module load.

The `_app.py` module implements an interactive LaTeX editor that spins up a local Flask server on demand. It is an opt-in interactive feature, reached only by calling `launch_editor()` or instantiating `LaTeXEditor(...)`. Importing it — let alone importing any ancestor package — should not require flask.

## Root cause

```
scitex.io  (line 89:  from . import bundle)
  → scitex.io.bundle.__init__  (line 43:  from ._Bundle import ...)
    → _Bundle.py  (line 29:  from .kinds._plot import ...)
      → kinds/__init__.py  (line 22:  from ._table import ...)
        → _table/__init__.py  (line 20:  from ._latex import ...)
          → _latex/__init__.py  (line 20:  from ._editor import ...)
            → _editor/__init__.py  (line 7:  from ._app import ...)
              → _app.py  (line 15:  from flask import Flask, ...)
                ↑ crash here on fresh venvs
```

Every layer is an eager `__init__.py` import. Any optional dep at the leaf (flask here, also `bs4` for `scitex.web`, see sibling [#279](https://github.com/ywatanabe1989/todo/issues/279)) breaks the top-level public API.

## Change

`src/scitex/io/bundle/kinds/_table/_latex/_editor/_app.py`, one file, two function-local imports and an updated module docstring:

```diff
-from flask import Flask, jsonify, render_template_string, request
-
 from .._validator import ValidationResult, validate_latex
 ...
 class LaTeXEditor:
     def __init__(self, latex_code, bundle=None, output_path=None):
+        from flask import Flask  # lazy: see module docstring, todo#441
         self.latex_code = latex_code
         ...
         self.app = Flask(__name__)
         self._setup_routes()

     def _setup_routes(self) -> None:
         """Setup Flask routes."""
+        from flask import (  # lazy: see module docstring, todo#441
+            jsonify,
+            render_template_string,
+            request,
+        )
         @self.app.route("/")
         def index(): ...
```

The pre-existing function-local `from flask import send_file` at line ~660 is unchanged.

Module docstring updated to explain why the imports are lazy and to point at `todo#441` for future maintainers who might otherwise "clean up" the pattern back to top-level imports.

## Verification

On MBA `~/.venv` (editable install of this branch, **`flask` NOT installed**):

```
$ grep -c '^from flask\|^import flask' src/scitex/io/bundle/kinds/_table/_latex/_editor/_app.py
0

$ python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location(
    "qc_verify", "src/scitex/io/bundle/kinds/_table/_latex/_editor/_app.py")
mod = importlib.util.module_from_spec(spec)
try: spec.loader.exec_module(mod)
except ImportError as e:
    assert "flask" not in str(e).lower(), f"flask leak still present: {e}"
print("flask leak gone")
PY
flask leak gone
```

Instantiating `LaTeXEditor(latex_code)` still raises `ModuleNotFoundError: No module named 'flask'` when flask is absent — that's the correct semantic for an optional interactive feature, and matches the behavior of every other opt-in scitex subfeature.

## Narrow scope caveat

During the audit I reached for `import scitex.io` as an end-to-end verification step and discovered **two additional optional-dep leaks** that surface once the flask one is removed:

1. `scitex.io._load → scitex.decorators.__init__ → _cache_disk (and _cache_disk_async) → joblib` — top-level `from joblib import Memory` in both `_cache_disk.py` and `_cache_disk_async.py`.
2. `scitex.io._save → _save_modules → scitex_io._save_modules._mp4 → matplotlib` — top-level `from matplotlib import animation` inside `scitex_io` (a separate package).

Both are the same class of bug in different leaves. I am intentionally **not** bundling them into this PR because:

- (a) they live in different modules (decorators, scitex_io) and each PR should have a single reviewer per domain;
- (b) the joblib leak deserves its own discussion about whether `@cache_disk` should gracefully no-op when joblib is missing or require it hard;
- (c) cramming four file edits into a PR titled "flask leak" would hide them from the audit trail.

I will file both as separate issues cross-referencing this PR and #441. The structural solution for this class of bug — PEP 562 lazy `__getattr__` at `scitex.io.__init__` level — is also a legitimate follow-up worth considering on its own issue, and is mentioned in #279's reopen thread.

**Net effect of this PR alone**: flask is no longer the crash point for `import scitex.io`. Users will still hit the next leak down (joblib) until the follow-up PRs land. The issue #441 is literally about flask, so this PR closes it correctly; joblib/matplotlib get their own issues.

## Related

- [ywatanabe1989/todo#441](https://github.com/ywatanabe1989/todo/issues/441) — this PR's target
- [ywatanabe1989/todo#279](https://github.com/ywatanabe1989/todo/issues/279) — sibling bug (bs4 leak via `scitex.web`), [PR #212](https://github.com/ywatanabe1989/scitex-python/pull/212) applies the same class of fix plus a structural `LazyGroup.get_command` tolerance improvement
- [ywatanabe1989/todo#438](https://github.com/ywatanabe1989/todo/issues/438) — broader CLI convention scorecard
- [ywatanabe1989/todo#157](https://github.com/ywatanabe1989/todo/issues/157) — `scitex.resource` import-time side effect (another same-class leak)

🤖 Generated by mamba-quality-checker-mba (Orochi fleet quality auditor).
