### PR TITLE
fix(decorators): lazy-import joblib in cache_disk + cache_disk_async (#442)

### DIFF
--- a/src/scitex/decorators/_cache_disk.py
+++ b/src/scitex/decorators/_cache_disk.py
@@ -13,13 +13,18 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import functools
 
-from joblib import Memory as _Memory
-
 from scitex.config import get_paths
 
 
 def cache_disk(func):
     """Disk caching decorator that uses joblib.Memory.
+
+    joblib is lazy-imported to keep ``import scitex.decorators`` (and the
+    transitive ``import scitex.io`` chain) usable on venvs without joblib
+    installed. Without lazy-import, the eager ``from joblib import Memory``
+    raised ``ModuleNotFoundError: No module named 'joblib'`` at import
+    time and broke any caller of scitex.io that didn't need caching at
+    all (todo#442, same class as #441 / #279).
 
     Usage:
         @cache_disk
@@ -27,6 +32,8 @@ def cache_disk(func):
             return x ** 2
     """
     cache_dir = str(get_paths().function_cache)
+    from joblib import Memory as _Memory  # lazy: see todo#442
+
     memory = _Memory(cache_dir, verbose=0)
 
     @functools.wraps(func)

--- a/src/scitex/decorators/_cache_disk_async.py
+++ b/src/scitex/decorators/_cache_disk_async.py
@@ -15,13 +15,17 @@ __DIR__ = os.path.dirname(__FILE__)
 import asyncio
 import functools
 
-from joblib import Memory as _Memory
-
 from scitex.config import get_paths
 
 
 def cache_disk_async(func):
     """Disk caching decorator for async functions.
+
+    joblib is lazy-imported inside the decorator body so that ``import
+    scitex.decorators`` does not fail on venvs without joblib (todo#442,
+    same class as #441 / #279). Without this, the eager top-level
+    ``from joblib import Memory`` propagates ``ModuleNotFoundError`` up
+    the ``scitex.io`` import chain and breaks unrelated callers.
 
     Usage:
         @cache_disk_async
@@ -30,6 +34,8 @@ def cache_disk_async(func):
             return x ** 2
     """
     cache_dir = str(get_paths().function_cache)
+    from joblib import Memory as _Memory  # lazy: see todo#442
+
     memory = _Memory(cache_dir, verbose=0)
 
     # Create sync wrapper for joblib

--- a/tests/scitex/decorators/test__cache_disk.py
+++ b/tests/scitex/decorators/test__cache_disk.py
@@ -15,7 +15,16 @@ import tempfile
 import time
 from unittest.mock import MagicMock, patch
 
-from joblib import Memory
+# joblib was changed from top-level eager import to lazy-import inside the
+# decorator body (todo#442). The legacy tests in this file depend on
+# joblib being available (they construct Memory objects directly). The new
+# regression test for the lazy-import behavior lives in a sibling file
+# (test__lazy_imports.py) so it can run on venvs without joblib.
+joblib = pytest.importorskip(
+    "joblib",
+    reason="legacy cache_disk tests need joblib; lazy-import regression in test__lazy_imports.py",
+)
+Memory = joblib.Memory
 
 
 def create_cache_disk_decorator(cache_dir):

--- a/tests/scitex/decorators/test__lazy_imports.py
+++ b/tests/scitex/decorators/test__lazy_imports.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex/decorators/test__lazy_imports.py
+
+"""Regression tests for the joblib eager-import leak (todo#442).
+
+The bug: pre-fix, ``import scitex.decorators`` (and the transitive
+``import scitex.io`` chain) raised ``ModuleNotFoundError: No module
+named 'joblib'`` whenever joblib wasn't installed in the venv, because
+``_cache_disk.py`` and ``_cache_disk_async.py`` had top-level
+``from joblib import Memory as _Memory``.
+
+The fix: joblib is lazy-imported inside ``cache_disk()`` /
+``cache_disk_async()`` function bodies only. ``import scitex.decorators``
+must succeed without joblib; only constructing the decorator (= calling
+it on a target function) requires joblib.
+
+Same class of bug as #441 (flask), #279 (bs4), #443 (matplotlib).
+
+This test file is intentionally separate from ``test__cache_disk.py``
+because the latter eager-imports ``joblib.Memory`` for legacy tests and
+gets skipped wholesale on no-joblib venvs — defeating the regression
+guard. The tests below run unconditionally and only inspect module
+source for the offending top-level import lines.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_cache_disk_module_has_no_top_level_joblib_import():
+    """``_cache_disk.py`` must not import joblib at module scope."""
+    from scitex.decorators import _cache_disk as mod
+
+    src = inspect.getsource(mod)
+    for lineno, line in enumerate(src.splitlines(), 1):
+        if line.startswith("from joblib") or line.startswith("import joblib"):
+            raise AssertionError(
+                f"Top-level joblib import re-introduced in _cache_disk.py "
+                f"at line {lineno}: {line!r}.\n"
+                "Lazy-import inside cache_disk() is required to keep "
+                "`import scitex.decorators` working on venvs without "
+                "joblib (todo#442)."
+            )
+
+
+def test_cache_disk_async_module_has_no_top_level_joblib_import():
+    """``_cache_disk_async.py`` must not import joblib at module scope."""
+    from scitex.decorators import _cache_disk_async as mod
+
+    src = inspect.getsource(mod)
+    for lineno, line in enumerate(src.splitlines(), 1):
+        if line.startswith("from joblib") or line.startswith("import joblib"):
+            raise AssertionError(
+                f"Top-level joblib import re-introduced in "
+                f"_cache_disk_async.py at line {lineno}: {line!r}.\n"
+                "Lazy-import inside cache_disk_async() is required "
+                "(todo#442)."
+            )
+
+
+def test_import_scitex_decorators_does_not_require_joblib():
+    """The package ``scitex.decorators`` must import without joblib.
+
+    This is the contract surfaced by todo#442. We assert by inspection
+    on the decorator source files (above) rather than runtime mocking,
+    because pytest's import system does not let us cleanly re-import
+    a module that the test runner has already loaded earlier in the
+    session. Source inspection is a sufficient regression guard: if
+    no top-level joblib import exists in either file, the contract
+    holds at import time.
+    """
+    # Sanity: importing the package itself must not raise. (It may have
+    # already been imported in an earlier test; that's fine.)
+    import scitex.decorators  # noqa: F401
+
+
+# EOF


### PR DESCRIPTION
Lazy-imports joblib in cache_disk() / cache_disk_async() function bodies so that import scitex.decorators succeeds without joblib installed. 3 source-inspection regression tests in new test__lazy_imports.py. Closes todo#442.