### PR TITLE
feat(cli): scitex-pkg audit — venv drift detection + auto-fix (mgr-pkg dependency, msg#16799)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ Repository = "https://github.com/ywatanabe1989/scitex-python"
 
 [project.scripts]
 scitex = "scitex.__main__:main"
+# Package-management CLI (venv drift detector for mgr-pkg autonomous ops)
+scitex-pkg = "scitex.cli.pkg:pkg"
 # MCP Server entry points (individual modules)
 # scitex-audio entry point now in standalone scitex-audio package
 scitex-canvas = "scitex.canvas.mcp_server:main"

--- a/src/scitex/cli/main.py
+++ b/src/scitex/cli/main.py
@@ -103,6 +103,7 @@ _LAZY_SUBCOMMANDS = {
         "Notification and alerting tools.",
     ),  # backward compat alias
     "notebook": ("scitex.cli.notebook", "notebook", "Jupyter notebook tools."),
+    "pkg": ("scitex.cli.pkg", "pkg", "Package management (venv drift audit)."),
     "plt": ("scitex.cli.plt", "plt", "Plotting tools."),
     "repro": ("scitex.cli.repro", "repro", "Reproducibility tools."),
     "resource": ("scitex.cli.resource", "resource", "Resource management."),

--- a/src/scitex/cli/pkg.py
+++ b/src/scitex/cli/pkg.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""SciTeX package-management CLI (``scitex-pkg``).
+
+Currently provides the ``audit`` subcommand — an autonomous
+virtualenv-drift detector. It inspects a hardcoded list of
+``scitex-*`` packages (overridable via env / config), checks that
+each one is both pip-installed *and* importable, and optionally
+re-installs the package from a local editable checkout when drift
+is detected.
+
+This CLI is driven on the ``mgr-pkg`` agent host by orochi-cron at
+startup (see lead msg#16799 item B); it is also useful as a
+developer-run sanity check.
+
+Exit codes (with ``--quiet``):
+    0 = all packages ok
+    1 = one or more packages in ``drift`` or ``missing`` state
+    2 = auto-fix attempted but failed
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import click
+
+# ---------------------------------------------------------------------------
+# Target package set
+# ---------------------------------------------------------------------------
+# Hardcoded defaults per the msg#16799 spec. Keep this list ordered —
+# users reading the terminal output benefit from a stable order.
+DEFAULT_TARGET_PACKAGES: tuple[str, ...] = (
+    "scitex",
+    "scitex-orochi",
+    "scitex-agent-container",
+    "scitex-clew",
+    "scitex-cloud",
+)
+
+# Map distribution name -> python import name. pip installs use dashes,
+# python imports use underscores.
+_IMPORT_NAME_OVERRIDES: dict[str, str] = {
+    "scitex": "scitex",
+    "scitex-orochi": "scitex_orochi",
+    "scitex-agent-container": "scitex_agent_container",
+    "scitex-clew": "scitex_clew",
+    "scitex-cloud": "scitex_cloud",
+}
+
+
+def _import_name(pkg: str) -> str:
+    """Return the python import name for a distribution ``pkg``."""
+    if pkg in _IMPORT_NAME_OVERRIDES:
+        return _IMPORT_NAME_OVERRIDES[pkg]
+    return pkg.replace("-", "_")
+
+
+def _repo_path_for(pkg: str) -> Path:
+    """Default local repo path used by ``--auto-fix``.
+
+    Convention: ``~/proj/<pkg>`` — matches the fleet's standard
+    ``~/proj`` checkout root. Override by placing a same-named
+    directory under ``$SCITEX_PROJ_ROOT`` if the env var is set.
+    """
+    root = os.environ.get("SCITEX_PROJ_ROOT")
+    base = Path(root).expanduser() if root else Path.home() / "proj"
+    # Special-case: the core package lives at ``scitex-python``
+    if pkg == "scitex":
+        candidates = [base / "scitex-python", base / "scitex"]
+    else:
+        candidates = [base / pkg]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Return the first candidate even if missing — caller checks .exists()
+    return candidates[0]
+
+
+def _extra_packages_from_env() -> list[str]:
+    """Return additional packages from ``SCITEX_PKG_AUDIT_EXTRA`` env var.
+
+    The value is a comma- or whitespace-separated list. Duplicates of
+    packages already in the default list are filtered out upstream.
+    """
+    raw = os.environ.get("SCITEX_PKG_AUDIT_EXTRA", "").strip()
+    if not raw:
+        return []
+    parts: list[str] = []
+    for chunk in raw.replace(",", " ").split():
+        chunk = chunk.strip()
+        if chunk:
+            parts.append(chunk)
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+@dataclass
+class PackageAuditResult:
+    """Outcome of auditing a single package.
+
+    Attributes
+    ----------
+    pkg : str
+        The distribution name, e.g. ``scitex-orochi``.
+    status : str
+        One of ``ok``, ``drift``, ``missing``.
+    repo_path : Optional[str]
+        Resolved local repo path (if any).
+    version : Optional[str]
+        Installed version from ``pip show`` (if any).
+    import_ok : bool
+        Whether ``python -c 'import <pkg>'`` succeeded.
+    fix_attempted : bool
+        Whether ``--auto-fix`` actually ran ``pip install -e``.
+    fix_result : Optional[str]
+        One of ``succeeded``, ``failed``, or ``None`` if not attempted.
+    error : Optional[str]
+        Short error message captured when available.
+    """
+
+    pkg: str
+    status: str
+    repo_path: Optional[str] = None
+    version: Optional[str] = None
+    import_ok: bool = False
+    fix_attempted: bool = False
+    fix_result: Optional[str] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Return a plain-dict representation for JSON serialisation."""
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Core audit primitives (wrap subprocess so tests can patch them)
+# ---------------------------------------------------------------------------
+def _pip_show(pkg: str) -> Optional[str]:
+    """Return installed version from ``pip show <pkg>`` or None if not found.
+
+    A return of ``None`` means pip does not have the package in the current
+    environment. A non-empty string is the reported ``Version:`` line.
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "show", pkg],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    for line in proc.stdout.splitlines():
+        if line.lower().startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _python_import_ok(import_name: str) -> tuple[bool, Optional[str]]:
+    """Run ``python -c 'import <name>'`` in a subprocess.
+
+    Returns ``(ok, error_message)``. A clean subprocess is used so a
+    failing import of a sibling package doesn't poison the auditor's
+    own process.
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", f"import {import_name}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return False, str(exc)
+    if proc.returncode == 0:
+        return True, None
+    err = (proc.stderr or proc.stdout or "").strip()
+    # Keep error short — last non-empty line is usually the exception
+    last_line = err.splitlines()[-1] if err else ""
+    return False, last_line or None
+
+
+def _pip_install_editable(repo_path: Path) -> tuple[bool, Optional[str]]:
+    """Attempt ``pip install -e <repo_path>``. Returns ``(ok, error)``."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-e", str(repo_path)],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return False, str(exc)
+    if proc.returncode == 0:
+        return True, None
+    err = (proc.stderr or proc.stdout or "").strip()
+    last_line = err.splitlines()[-1] if err else ""
+    return False, last_line or f"pip exited {proc.returncode}"
+
+
+# ---------------------------------------------------------------------------
+# Per-package audit
+# ---------------------------------------------------------------------------
+def audit_package(pkg: str, auto_fix: bool = False) -> PackageAuditResult:
+    """Audit a single package and return a ``PackageAuditResult``.
+
+    The algorithm:
+      1. ``pip show <pkg>`` — establishes "pip thinks it's installed".
+      2. ``python -c 'import <pkg>'`` — establishes "it actually works".
+      3. If both pass → ``ok``.
+         If pip-only → ``drift`` (e.g. editable install that lost its src).
+         If neither → ``missing``.
+      4. If ``auto_fix`` and a local repo path exists, run
+         ``pip install -e <repo_path>`` then re-verify the import.
+    """
+    import_name = _import_name(pkg)
+    repo_path = _repo_path_for(pkg)
+    repo_path_str = str(repo_path) if repo_path.exists() else None
+
+    version = _pip_show(pkg)
+    import_ok, import_err = _python_import_ok(import_name)
+
+    if version and import_ok:
+        status = "ok"
+        error = None
+    elif version and not import_ok:
+        status = "drift"
+        error = import_err
+    else:
+        status = "missing"
+        error = import_err
+
+    result = PackageAuditResult(
+        pkg=pkg,
+        status=status,
+        repo_path=repo_path_str,
+        version=version,
+        import_ok=import_ok,
+        error=error,
+    )
+
+    if auto_fix and status != "ok" and repo_path_str:
+        result.fix_attempted = True
+        ok, err = _pip_install_editable(repo_path)
+        if ok:
+            # Re-verify import now that pip has (re)installed.
+            import_ok_after, import_err_after = _python_import_ok(import_name)
+            if import_ok_after:
+                result.fix_result = "succeeded"
+                result.status = "ok"
+                result.import_ok = True
+                result.error = None
+                result.version = _pip_show(pkg) or result.version
+            else:
+                result.fix_result = "failed"
+                result.error = import_err_after or "import still fails after reinstall"
+        else:
+            result.fix_result = "failed"
+            result.error = err
+
+    return result
+
+
+def _status_emoji(status: str) -> str:
+    """Return a non-ANSI emoji badge for ``status`` (used in text output)."""
+    return {
+        "ok": "OK",
+        "drift": "DRIFT",
+        "missing": "MISSING",
+    }.get(status, status.upper())
+
+
+def _status_color(status: str) -> str:
+    return {
+        "ok": "green",
+        "drift": "yellow",
+        "missing": "red",
+    }.get(status, "white")
+
+
+# ---------------------------------------------------------------------------
+# Click CLI
+# ---------------------------------------------------------------------------
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def pkg():
+    """SciTeX package-management CLI.
+
+    \b
+    Subcommands:
+      audit    Check installed scitex-* packages for venv drift.
+    """
+
+
+@pkg.command()
+@click.option(
+    "--auto-fix",
+    is_flag=True,
+    help="Attempt to re-install from the local repo when drift is detected.",
+)
+@click.option(
+    "--host",
+    type=str,
+    default=None,
+    help="Audit a specific remote host via SSH (not yet implemented).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit NDJSON — one JSON object per package, one per line.",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Suppress human output. Exit code reflects outcome.",
+)
+@click.option(
+    "--pkg",
+    "single_pkg",
+    type=str,
+    default=None,
+    help="Audit only one package (distribution name).",
+)
+def audit(auto_fix, host, as_json, quiet, single_pkg):
+    """Audit installed scitex-* packages for venv drift.
+
+    \b
+    Examples:
+      scitex-pkg audit                          # human text, read-only
+      scitex-pkg audit --auto-fix               # repair any drift found
+      scitex-pkg audit --json                   # NDJSON output
+      scitex-pkg audit --pkg scitex-orochi      # audit one package
+      scitex-pkg audit --auto-fix --quiet       # cron-style (exit code only)
+    """
+    # --host is a stub; remote audit lives in a future iteration so the
+    # orochi-cron entry on mgr-pkg stays simple.
+    if host:
+        msg = f"remote audit not implemented (requested --host {host})"
+        if as_json:
+            click.echo(json.dumps({"error": msg, "host": host}))
+        elif not quiet:
+            click.secho(msg, fg="yellow", err=True)
+        sys.exit(2)
+
+    if single_pkg:
+        targets: list[str] = [single_pkg]
+    else:
+        # De-duplicate while preserving order.
+        seen: set[str] = set()
+        targets = []
+        for name in list(DEFAULT_TARGET_PACKAGES) + _extra_packages_from_env():
+            if name not in seen:
+                seen.add(name)
+                targets.append(name)
+
+    results: list[PackageAuditResult] = []
+    for name in targets:
+        result = audit_package(name, auto_fix=auto_fix)
+        results.append(result)
+        if as_json:
+            click.echo(json.dumps(result.to_dict(), sort_keys=True))
+        elif not quiet:
+            badge = click.style(
+                _status_emoji(result.status),
+                fg=_status_color(result.status),
+                bold=True,
+            )
+            version_str = f" v{result.version}" if result.version else ""
+            fix_note = ""
+            if result.fix_attempted:
+                fix_note = f" [fix:{result.fix_result}]"
+            error_note = f" — {result.error}" if result.error and result.status != "ok" else ""
+            click.echo(f"  {badge:20s} {result.pkg}{version_str}{fix_note}{error_note}")
+
+    # Exit-code semantics
+    any_non_ok = any(r.status != "ok" for r in results)
+    any_fix_failed = any(
+        r.fix_attempted and r.fix_result == "failed" for r in results
+    )
+    if any_fix_failed:
+        sys.exit(2)
+    if any_non_ok:
+        sys.exit(1)
+    sys.exit(0)
+
+
+# Allow ``python -m scitex.cli.pkg`` for quick manual runs
+if __name__ == "__main__":
+    pkg()
+
+# EOF

--- a/tests/scitex/cli/test_pkg.py
+++ b/tests/scitex/cli/test_pkg.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Tests for ``scitex.cli.pkg`` — the ``scitex-pkg audit`` CLI.
+
+These tests mock the three subprocess primitives
+(``_pip_show``, ``_python_import_ok``, ``_pip_install_editable``)
+so no network, pip, or real python imports happen during test runs.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from scitex.cli.pkg import (
+    DEFAULT_TARGET_PACKAGES,
+    PackageAuditResult,
+    _import_name,
+    _repo_path_for,
+    audit_package,
+    pkg,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+class TestHelpers:
+    """Sanity checks for the pure helpers."""
+
+    def test_import_name_known(self):
+        assert _import_name("scitex-orochi") == "scitex_orochi"
+        assert _import_name("scitex-agent-container") == "scitex_agent_container"
+        assert _import_name("scitex") == "scitex"
+
+    def test_import_name_unknown_falls_back_to_dash_underscore(self):
+        assert _import_name("totally-new-pkg") == "totally_new_pkg"
+
+    def test_default_targets_include_required(self):
+        # msg#16799 spec — guard against accidental deletion
+        for required in (
+            "scitex",
+            "scitex-orochi",
+            "scitex-agent-container",
+            "scitex-clew",
+            "scitex-cloud",
+        ):
+            assert required in DEFAULT_TARGET_PACKAGES
+
+    def test_repo_path_for_scitex_prefers_scitex_python(self, tmp_path, monkeypatch):
+        # Force root at tmp_path and create scitex-python dir
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+        (tmp_path / "scitex-python").mkdir()
+        assert _repo_path_for("scitex") == tmp_path / "scitex-python"
+
+    def test_repo_path_for_other_pkg(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+        (tmp_path / "scitex-orochi").mkdir()
+        assert _repo_path_for("scitex-orochi") == tmp_path / "scitex-orochi"
+
+
+# ---------------------------------------------------------------------------
+# audit_package (the core engine)
+# ---------------------------------------------------------------------------
+class TestAuditPackageHappyPath:
+    """pip show OK + import OK → status ok."""
+
+    def test_ok(self):
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = audit_package("scitex-orochi")
+        assert result.status == "ok"
+        assert result.version == "1.2.3"
+        assert result.import_ok is True
+        assert result.fix_attempted is False
+        assert result.fix_result is None
+        assert result.error is None
+
+
+class TestAuditPackageDrift:
+    """pip show OK but import fails → status drift."""
+
+    def test_drift_without_auto_fix(self):
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok",
+            return_value=(False, "ModuleNotFoundError: no module named 'x'"),
+        ):
+            result = audit_package("scitex-orochi", auto_fix=False)
+        assert result.status == "drift"
+        assert result.version == "1.2.3"
+        assert result.import_ok is False
+        assert result.fix_attempted is False
+        assert "ModuleNotFoundError" in (result.error or "")
+
+    def test_drift_with_auto_fix_succeeds(self, tmp_path, monkeypatch):
+        # Local repo exists
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+        (tmp_path / "scitex-orochi").mkdir()
+
+        # First import fails, then pip install -e succeeds, then re-import works
+        import_calls = {"n": 0}
+
+        def fake_import(_name):
+            import_calls["n"] += 1
+            if import_calls["n"] == 1:
+                return (False, "boom")
+            return (True, None)
+
+        with patch(
+            "scitex.cli.pkg._pip_show", side_effect=["1.2.3", "1.2.3"]
+        ), patch(
+            "scitex.cli.pkg._python_import_ok", side_effect=fake_import
+        ), patch(
+            "scitex.cli.pkg._pip_install_editable", return_value=(True, None)
+        ) as mock_install:
+            result = audit_package("scitex-orochi", auto_fix=True)
+
+        mock_install.assert_called_once()
+        assert result.fix_attempted is True
+        assert result.fix_result == "succeeded"
+        assert result.status == "ok"
+        assert result.import_ok is True
+
+    def test_drift_with_auto_fix_fails(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+        (tmp_path / "scitex-orochi").mkdir()
+
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(False, "boom")
+        ), patch(
+            "scitex.cli.pkg._pip_install_editable",
+            return_value=(False, "pip: error"),
+        ):
+            result = audit_package("scitex-orochi", auto_fix=True)
+
+        assert result.fix_attempted is True
+        assert result.fix_result == "failed"
+        assert result.status == "drift"
+        assert "pip: error" in (result.error or "")
+
+    def test_drift_with_auto_fix_but_no_repo(self, tmp_path, monkeypatch):
+        # Point proj root at tmp with no repo dir — auto-fix should skip.
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(False, "boom")
+        ), patch(
+            "scitex.cli.pkg._pip_install_editable"
+        ) as mock_install:
+            result = audit_package("scitex-orochi", auto_fix=True)
+
+        mock_install.assert_not_called()
+        assert result.fix_attempted is False
+        assert result.status == "drift"
+
+
+class TestAuditPackageMissing:
+    """pip show missing → status missing."""
+
+    def test_missing(self):
+        with patch("scitex.cli.pkg._pip_show", return_value=None), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(False, "not found")
+        ):
+            result = audit_package("scitex-orochi")
+        assert result.status == "missing"
+        assert result.version is None
+        assert result.import_ok is False
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (click.testing.CliRunner)
+# ---------------------------------------------------------------------------
+class TestCliBasics:
+    def test_pkg_help(self):
+        runner = CliRunner()
+        result = runner.invoke(pkg, ["--help"])
+        assert result.exit_code == 0
+        assert "audit" in result.output
+
+    def test_audit_help(self):
+        runner = CliRunner()
+        result = runner.invoke(pkg, ["audit", "--help"])
+        assert result.exit_code == 0
+        assert "venv drift" in result.output.lower() or "drift" in result.output.lower()
+
+
+class TestCliAllOk:
+    def test_exit_zero_when_all_ok(self):
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = runner.invoke(pkg, ["audit", "--pkg", "scitex-orochi"])
+        assert result.exit_code == 0
+        assert "scitex-orochi" in result.output
+
+
+class TestCliDriftExitCode:
+    def test_exit_one_on_drift(self):
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(False, "bad")
+        ):
+            result = runner.invoke(
+                pkg, ["audit", "--pkg", "scitex-orochi", "--quiet"]
+            )
+        assert result.exit_code == 1
+        # quiet -> stdout should not contain status table
+        assert "DRIFT" not in result.output
+
+    def test_exit_two_on_fix_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCITEX_PROJ_ROOT", str(tmp_path))
+        (tmp_path / "scitex-orochi").mkdir()
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(False, "bad")
+        ), patch(
+            "scitex.cli.pkg._pip_install_editable",
+            return_value=(False, "pip: error"),
+        ):
+            result = runner.invoke(
+                pkg,
+                ["audit", "--pkg", "scitex-orochi", "--auto-fix", "--quiet"],
+            )
+        assert result.exit_code == 2
+
+
+class TestCliJsonOutput:
+    def test_json_ndjson_schema(self):
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = runner.invoke(
+                pkg, ["audit", "--pkg", "scitex-orochi", "--json"]
+            )
+        assert result.exit_code == 0
+        lines = [line for line in result.output.splitlines() if line.strip()]
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        for key in (
+            "pkg",
+            "status",
+            "repo_path",
+            "version",
+            "import_ok",
+            "fix_attempted",
+            "fix_result",
+        ):
+            assert key in payload
+        assert payload["pkg"] == "scitex-orochi"
+        assert payload["status"] == "ok"
+        assert payload["version"] == "1.2.3"
+        assert payload["import_ok"] is True
+
+    def test_json_multi_package_ndjson(self):
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = runner.invoke(pkg, ["audit", "--json"])
+        assert result.exit_code == 0
+        lines = [line for line in result.output.splitlines() if line.strip()]
+        # One line per default target package
+        assert len(lines) == len(DEFAULT_TARGET_PACKAGES)
+        for line in lines:
+            payload = json.loads(line)
+            assert payload["status"] == "ok"
+
+
+class TestCliRemoteHostStub:
+    def test_host_stub_says_not_implemented(self):
+        runner = CliRunner()
+        result = runner.invoke(pkg, ["audit", "--host", "mba"])
+        # Exit 2 = error (not implemented)
+        assert result.exit_code == 2
+
+
+class TestCliQuietMode:
+    def test_quiet_suppresses_human_output(self):
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="1.2.3"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = runner.invoke(
+                pkg, ["audit", "--pkg", "scitex-orochi", "--quiet"]
+            )
+        assert result.exit_code == 0
+        # No package-listing noise
+        assert result.output.strip() == ""
+
+
+class TestCliExtraPackagesFromEnv:
+    def test_env_extra_packages_are_audited(self, monkeypatch):
+        monkeypatch.setenv("SCITEX_PKG_AUDIT_EXTRA", "some-extra-pkg")
+        runner = CliRunner()
+        with patch("scitex.cli.pkg._pip_show", return_value="0.1.0"), patch(
+            "scitex.cli.pkg._python_import_ok", return_value=(True, None)
+        ):
+            result = runner.invoke(pkg, ["audit", "--json"])
+        assert result.exit_code == 0
+        packages_in_output = {
+            json.loads(line)["pkg"]
+            for line in result.output.splitlines()
+            if line.strip()
+        }
+        assert "some-extra-pkg" in packages_in_output
+        # Defaults still present
+        assert "scitex-orochi" in packages_in_output
+
+
+if __name__ == "__main__":
+    import os
+
+    pytest.main([os.path.abspath(__file__)])
+
+# EOF


### PR DESCRIPTION
## Summary

Adds a new CLI entry point `scitex-pkg audit` that autonomously detects
virtualenv drift across the `scitex-*` package family and can repair it
by re-running editable installs.

This is the dependency called out in lead **msg#16799 item B**:
`mgr-pkg` on its orochi-cron startup will run
`scitex-pkg audit --auto-fix --quiet` on a schedule, with no human in
the loop. Wiring that cron entry is head-ywata-note-win's lane — this
PR only lands the CLI so the cron command has something to invoke.

- New file: `src/scitex/cli/pkg.py` — Click group `pkg` + `audit` verb.
- New tests: `tests/scitex/cli/test_pkg.py` — 21 tests, all subprocess
  calls mocked (no real pip / import in test runs).
- `pyproject.toml`: added `scitex-pkg = "scitex.cli.pkg:pkg"` script.
- `src/scitex/cli/main.py`: registered `pkg` in `_LAZY_SUBCOMMANDS` so
  `scitex pkg audit` also works.

### Algorithm

For each target package:
1. `pip show <pkg>` — confirms installed with a version.
2. Subprocess `python -c 'import <pkg>'` — confirms importable.
3. Classify: both ok = `ok`; installed-but-not-importable = `drift`;
   neither = `missing`.
4. If `--auto-fix` and `~/proj/<pkg>` exists, run `pip install -e <path>`
   and re-verify the import.

### Default target list

`scitex`, `scitex-orochi`, `scitex-agent-container`, `scitex-clew`,
`scitex-cloud`. Extensible via `SCITEX_PKG_AUDIT_EXTRA` env var.

### Flags

- `--auto-fix` — opt-in repair.
- `--host <name>` — remote audit stub; currently exits with a
  "not implemented" message.
- `--json` — NDJSON output (one object per package per line).
- `--quiet` — suppress stdout; exit code only.
- `--pkg <name>` — audit a single package.

### Exit codes

- `0` — all packages ok
- `1` — one or more packages in drift / missing state
- `2` — auto-fix was attempted but failed (or `--host` stub hit)

## Test plan

- [x] `pytest tests/scitex/cli/test_pkg.py` — 21 passed, 0 failed
- [x] Live smoke test: `scitex-pkg audit --json --pkg scitex` returns
      a valid NDJSON object for the installed package.
- [ ] Post-merge: head-ywata-note-win confirms `mgr-pkg` orochi-cron
      picks up the command and exit codes drive its retry loop.

## Notes / judgment calls

- Chose `scitex-python` over `scitex-agent-container` as the host repo
  because every fleet tool already depends on `scitex`, and
  `scitex-pkg` is a natural sibling to the existing `scitex` console
  script. This matches the "foundation package" framing in the spec.
- Repo-path convention is `~/proj/<pkg>` (with `scitex-python` as a
  special case for the core package). Overridable via
  `SCITEX_PROJ_ROOT`.
- `--host` is intentionally a stub — cross-host audit can land later
  once we agree on the SSH transport; the orochi-cron entry on
  `mgr-pkg` only needs local audit today.

Generated with [Claude Code](https://claude.com/claude-code)
