### PR TITLE
docs(interface-cli): clarify compound-verb hyphenation rule

### DIFF
--- a/src/scitex/_skills/general/interface-cli.md
+++ b/src/scitex/_skills/general/interface-cli.md
@@ -41,8 +41,21 @@ is noun first, then verb:
 <cli> <noun> <verb> [OPTIONS] [ARGS]
 ```
 
-Hyphenate multi-word nouns or verbs. Illustrative shape (names are
-placeholders, not a real command set):
+Hyphenate multi-word nouns or verbs.
+
+Compound verbs (verb phrases like "send heartbeat" or "fetch status")
+are collapsed into a single hyphenated token in the invocation
+(`send-heartbeat`, `fetch-status`) rather than being split into an
+extra argument, so the parser always sees exactly one noun and one
+verb. Example:
+
+    <cli> machine send-heartbeat --host <name>
+
+reads as `<cli>` → noun `machine` → verb `send-heartbeat` — not
+`<cli>` → `machine` → `send` → `heartbeat` — even though the verb
+is conceptually a two-word phrase.
+
+Illustrative shape (names are placeholders, not a real command set):
 
 ```
 <cli> resource list


### PR DESCRIPTION
## Summary

Adds a short paragraph to §1 of the canonical `interface-cli.md` skill showing that compound verb phrases (e.g. "send heartbeat") are rendered as a single hyphenated token in the invocation (`send-heartbeat`), so the parser always sees exactly one noun and one verb. The existing "Hyphenate multi-word nouns or verbs" line stays put; the new paragraph sits directly after it with a concrete `<cli> machine send-heartbeat --host <name>` example.

## Test plan

- [ ] visual diff inspection of §1