### PR TITLE
refactor(bridge): decouple from deprecated scitex.canvas.model

### DIFF
--- a/src/scitex/bridge/_helpers.py
+++ b/src/scitex/bridge/_helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # File: ./src/scitex/bridge/_helpers.py
 # Time-stamp: "2024-12-09 11:00:00 (ywatanabe)"
 """
@@ -9,7 +8,7 @@ These helpers provide a unified API for common workflows that span
 multiple modules, abstracting away backend-specific details.
 """
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
 # StatResult is now a dict - the GUI-specific StatResult is deprecated
 StatResult = dict
@@ -118,7 +117,7 @@ def _detect_backend(target) -> Literal["plt", "vis"]:
     """
     # Check for vis FigureModel
     try:
-        from scitex.canvas.model import FigureModel
+        from scitex.io.bundle.kinds._plot._models import FigureModel
 
         if isinstance(target, FigureModel):
             return "vis"

--- a/src/scitex/bridge/_plt_vis.py
+++ b/src/scitex/bridge/_plt_vis.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from scitex.canvas.model import (
+        from scitex.io.bundle.kinds._plot._models import (
             AnnotationModel,
             AxesModel,
             AxesStyle,

--- a/src/scitex/bridge/_stats_vis.py
+++ b/src/scitex/bridge/_stats_vis.py
@@ -30,7 +30,12 @@ from scitex.io.bundle.kinds._stats import Position
 
 # Legacy model imports - may not be available
 try:
-    from scitex.canvas.model import AnnotationModel, AxesModel, FigureModel, TextStyle
+    from scitex.io.bundle.kinds._plot._models import (
+        AnnotationModel,
+        AxesModel,
+        FigureModel,
+        TextStyle,
+    )
 
     VIS_MODEL_AVAILABLE = True
 except ImportError:

--- a/tests/scitex/bridge/test__helpers.py
+++ b/tests/scitex/bridge/test__helpers.py
@@ -41,7 +41,7 @@ class TestAddStatsFromResults:
     def test_auto_detect_figure_model(self, stat_results):
         """Test auto-detection works with FigureModel."""
         from scitex.bridge import add_stats_from_results
-        from scitex.canvas.model import FigureModel
+        from scitex.io.bundle.kinds._plot._models import FigureModel
 
         model = FigureModel(
             width_mm=170,
@@ -74,7 +74,7 @@ class TestAddStatsFromResults:
     def test_explicit_vis_backend(self, stat_results):
         """Test explicit vis backend."""
         from scitex.bridge import add_stats_from_results
-        from scitex.canvas.model import FigureModel
+        from scitex.io.bundle.kinds._plot._models import FigureModel
 
         model = FigureModel(
             width_mm=170,
@@ -280,7 +280,7 @@ if __name__ == "__main__":
 #     """
 #     # Check for vis FigureModel
 #     try:
-#         from scitex.canvas.model import FigureModel
+#         from scitex.io.bundle.kinds._plot._models import FigureModel
 #         if isinstance(target, FigureModel):
 #             return "vis"
 #     except ImportError:

--- a/tests/scitex/bridge/test__plt_vis.py
+++ b/tests/scitex/bridge/test__plt_vis.py
@@ -25,7 +25,7 @@ class TestFigureToVisModel:
     def test_converts_to_figure_model(self, mpl_figure):
         """Test conversion to FigureModel."""
         from scitex.bridge import figure_to_vis_model
-        from scitex.canvas.model import FigureModel
+        from scitex.io.bundle.kinds._plot._models import FigureModel
 
         model = figure_to_vis_model(mpl_figure)
 
@@ -78,7 +78,7 @@ class TestAxesToVisAxes:
     def test_creates_axes_model(self, mpl_axes):
         """Test creation of AxesModel."""
         from scitex.bridge import axes_to_vis_axes
-        from scitex.canvas.model import AxesModel
+        from scitex.io.bundle.kinds._plot._models import AxesModel
 
         model = axes_to_vis_axes(mpl_axes)
 
@@ -205,7 +205,7 @@ if __name__ == "__main__":
 #
 # # Legacy model imports - may not be available (deleted module)
 # try:
-#     from scitex.canvas.model import (
+#     from scitex.io.bundle.kinds._plot._models import (
 #         FigureModel,
 #         AxesModel,
 #         PlotModel,

--- a/tests/scitex/bridge/test__stats_vis.py
+++ b/tests/scitex/bridge/test__stats_vis.py
@@ -12,7 +12,7 @@ class TestStatResultToAnnotation:
     def test_creates_annotation_model(self):
         """Test that function creates AnnotationModel."""
         from scitex.bridge import stat_result_to_annotation
-        from scitex.canvas.model import AnnotationModel
+        from scitex.io.bundle.kinds._plot._models import AnnotationModel
         from scitex.schema import create_stat_result
 
         result = create_stat_result("t-test", "t", 2.5, 0.01)
@@ -53,7 +53,7 @@ class TestAddStatsToFigureModel:
     @pytest.fixture
     def figure_model(self):
         """Create a basic FigureModel."""
-        from scitex.canvas.model import FigureModel
+        from scitex.io.bundle.kinds._plot._models import FigureModel
 
         return FigureModel(
             width_mm=170,
@@ -160,7 +160,7 @@ if __name__ == "__main__":
 #
 # # Legacy model imports - may not be available
 # try:
-#     from scitex.canvas.model import AnnotationModel, AxesModel, FigureModel, TextStyle
+#     from scitex.io.bundle.kinds._plot._models import AnnotationModel, AxesModel, FigureModel, TextStyle
 #
 #     VIS_MODEL_AVAILABLE = True
 # except ImportError:


### PR DESCRIPTION
## Summary
- Rewire `scitex.bridge` module (3 files) + bridge tests (3 files) to import figure-model dataclasses from `scitex.io.bundle.kinds._plot._models` (canonical home) instead of `scitex.canvas.model` (deprecated, near-identical duplicate).
- Frees `scitex.canvas` of external dataclass dependents so it can be retired as a self-contained unit in a follow-up PR.
- No behavior change.

## Context
Part of media-domain restructuring. `scitex-vis` already moved to `~/proj/legacy/`. `scitex.canvas` is deprecated (uses `figrecipe` for `edit()`/`compose()`) but had heavy fan-out via `canvas.model.*` into `bridge/`, `io/`, and tests. After this PR, the only remaining external coupling to canvas is feature wiring (MCP server, `.canvas` IO format, `Canvas` class, console script) — those will be addressed when canvas itself moves to legacy.

## Test plan
- [x] `pytest tests/scitex/bridge/` — 30 passed, 8 xfailed (pre-existing), 1 unrelated failure in `test__stats_plt` (missing `scitex.stats._utils`, not introduced here)
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)