### PR TITLE
docs(rtd): mock mcp in autodoc to dodge pydantic 2.13 incompat

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -89,6 +89,9 @@ autodoc_mock_imports = [
     "scitex_cloud",
     # OpenAlex (pulls awscli causing pip deadlock)
     "openalex_local",
+    # MCP SDK — pydantic 2.13 incompat with currently-released mcp triggers
+    # PydanticSchemaGenerationError on import; mock for autodoc.
+    "mcp",
 ]
 
 # Autosummary settings

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,8 +1,10 @@
-# Pin mcp <= 1.25 — newer mcp.types.TaskMetadata declares
-# __pydantic_extra__ with a Dict forward-ref that pydantic cannot resolve
-# at class-creation, breaking Sphinx autodoc on RTD when mcp is pulled in
-# transitively via scitex-writer → fastmcp.
-mcp<=1.25
+# RTD-only pins: mcp.types.TaskMetadata declares __pydantic_extra__ with
+# an unqualified Dict forward-ref that recent pydantic strict-validates
+# and rejects. We need BOTH: pydantic<2.13 (skips the strict check) AND
+# mcp<1.20 (predates TaskMetadata entirely). mcp pulled in transitively
+# via scitex-writer → fastmcp.
+mcp<1.20
+pydantic<2.13
 
 sphinx>=7.0
 sphinx-rtd-theme>=2.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,7 +1,8 @@
-# Pin pydantic < 2.13 — released `mcp` SDK declares __pydantic_extra__ in a
-# way 2.13 rejects, breaking Sphinx autodoc on RTD when mcp is pulled in
-# transitively via scitex-writer/socialia.
-pydantic<2.13
+# Pin mcp <= 1.25 — newer mcp.types.TaskMetadata declares
+# __pydantic_extra__ with a Dict forward-ref that pydantic cannot resolve
+# at class-creation, breaking Sphinx autodoc on RTD when mcp is pulled in
+# transitively via scitex-writer → fastmcp.
+mcp<=1.25
 
 sphinx>=7.0
 sphinx-rtd-theme>=2.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,3 +1,8 @@
+# Pin pydantic < 2.13 — released `mcp` SDK declares __pydantic_extra__ in a
+# way 2.13 rejects, breaking Sphinx autodoc on RTD when mcp is pulled in
+# transitively via scitex-writer/socialia.
+pydantic<2.13
+
 sphinx>=7.0
 sphinx-rtd-theme>=2.0
 myst-parser>=2.0


### PR DESCRIPTION
## Summary
The released `mcp` SDK declares `__pydantic_extra__` with an annotation that pydantic 2.13 rejects with `PydanticSchemaGenerationError`, breaking Sphinx autodoc on Read the Docs:

```
File ".../mcp/types.py", line 49, in <module>
    class TaskMetadata(BaseModel):
pydantic.errors.PydanticSchemaGenerationError: The type annotation for
`__pydantic_extra__` must be `dict[str, ...]`
```

Mock `mcp` in `autodoc_mock_imports` like the other heavyweight optionals (`torch`, `playwright`, etc.). Runtime callers (the MCP server modules in `scitex/capture/_mcp/`, `scitex/notification/_mcp/`) still import `mcp` normally — only Sphinx is affected.

## Test plan
- [ ] RTD build succeeds on the next push to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)