### PR TITLE
docs(rtd): stub mcp/fastmcp before sphinx import to fix autodoc

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -7,6 +7,19 @@
 
 import os
 import sys
+import types
+
+# Stub `mcp` / `fastmcp` BEFORE any `import scitex` so autodoc never triggers
+# the broken pydantic schema generation in mcp.types.TaskMetadata. Real mcp is
+# pulled in transitively via scitex-writer → fastmcp; we don't need the actual
+# implementation to render docs. autodoc_mock_imports doesn't help because the
+# package is installed (so it's "present").
+for _name in ("mcp", "mcp.types", "mcp.server", "mcp.client", "fastmcp"):
+    if _name not in sys.modules:
+        _mod = types.ModuleType(_name)
+        if "." not in _name:
+            _mod.__path__ = []  # mark as package
+        sys.modules[_name] = _mod
 
 sys.path.insert(0, os.path.abspath("../../src"))
 


### PR DESCRIPTION
## Problem
\`autodoc_mock_imports\` only mocks **missing** modules. \`mcp\` is installed transitively (\`scitex-writer\` → \`fastmcp\` → \`mcp\`) on RTD, so its broken \`TaskMetadata\` pydantic class runs at import time and crashes sphinx with \`PydanticSchemaGenerationError\`.

## Fix
Insert a no-op \`ModuleType\` into \`sys.modules\` for \`mcp\` / \`fastmcp\` (and submodules) at the top of \`conf.py\`, before any \`import scitex\`. Real implementations aren't needed to render docs; members imported from \`mcp\` resolve to dummy attributes, autodoc lists them as undocumented and the build proceeds.

## Test plan
- [ ] RTD build succeeds for the next push to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)