### PR TITLE
ci(cla): allowlist LLEmacs identity

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-python/blob/main/CLA.md"
           branch: "cla-signatures"
-          allowlist: bot*,ywatanabe1989
+          allowlist: bot*,ywatanabe1989,LLEmacs
           custom-allsigned-prcomment: |
             Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
           custom-notsigned-prcomment: |


### PR DESCRIPTION
## Summary
Adds `LLEmacs` to the CLA Assistant allowlist alongside `ywatanabe1989`. Both are maintainer identities (Emacs-driven workflows publish under `LLEmacs`).

## Why now
PR #262 (Tier 1 umbrella simplification) carries one historical commit by `LLEmacs` (`768b6238`) that the current allowlist (`bot*,ywatanabe1989`) rejects. Updating the allowlist on `main` so `pull_request_target` picks it up.

## Test plan
- [ ] CLA passes on this PR (commits authored solely by `ywatanabe1989`)
- [ ] After merge, re-trigger CLA on PR #262 — should pass