### PR TITLE
chore: bump 2.28.4 -> 2.28.5 (Tier 1 simplification)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.28.4"
+version = "2.28.5"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Version bump for the Tier 1 umbrella simplification merged in #262.

## Changes since 2.28.4
- `refactor(umbrella)`: drop 4 deprecated alias directories (#262) — collapses `ml/`, `reproduce/`, `rng/`, `verify/` into a single `_DEPRECATED_MODULE_ALIASES` dict. −405/+19 lines. No behaviour change.
- `ci(cla)`: allowlist `LLEmacs` identity (#263)

## Test plan
- [ ] CI green on develop → main
- [ ] After merge: tag v2.28.5, create release, OIDC PyPI publish triggers