### PR TITLE
fix(deps): restore >= dep minima (was exact ==); fixes #282

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SciTeX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.29.3] - 2026-05-23
+
+### Fixed
+- **Dependency pins**: Restore `>=` minima for sibling `scitex-*` deps (was exact `==`, which referenced unpublished versions like `scitex-config==0.3.3` and broke `pip install scitex` with ResolutionImpossible). Fixes #282. The 2.29.0 and 2.29.1 PyPI releases shipped the broken `==` pins; 2.29.3 is the corrected release.
+
 ## [2.28.13] - 2026-04-30
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.29.2"
+version = "2.29.3"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Problem (#282)

scitex 2.29.0 and 2.29.1 on PyPI pin sibling `scitex-*` deps with exact `==` (e.g. `scitex-config==0.3.3`, which is not on PyPI), so `pip install scitex` fails with `ResolutionImpossible`. The ecosystem convention is `>=X.Y.Z` minima, never exact `==`.

## State of develop

develop HEAD already carries the corrected `>=` minima — there are zero `scitex-*==` exact pins in `pyproject.toml`. The `v2.29.2` git tag was cut off the *broken* commit (`8028068b`, 75 exact pins) and never published to PyPI (404). So no source change to the dep graph is needed; this PR ships the already-fixed graph as a clean release.

## Change

- Bump version 2.29.2 -> **2.29.3** (2.29.2 is a stale tag on the broken commit; bumping avoids any tag collision and gives an unambiguous corrected release).
- CHANGELOG entry documenting the `==` -> `>=` restoration.

## Verification

Clean dry-run resolve in a fresh uv venv (Python 3.11):

```
uv pip install --dry-run <repo>   # EXIT 0, no ResolutionImpossible
# scitex-config resolves to ==0.3.4 (satisfies >=0.3.3)
```

Resolved the full sibling matrix with no conflict. Fixes #282.