### PR TITLE
ci(docs): make _sphinx_html bundle commit-back non-fatal

### DIFF
--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -47,6 +47,13 @@ jobs:
           touch src/scitex/_sphinx_html/.nojekyll
 
       - name: Commit refreshed HTML if it changed (develop push only)
+        # Best-effort: develop is a protected branch, so the bot push is
+        # declined with GH006 ("protected branch hook declined"). The bundle
+        # only needs to be current for production serving, which is refreshed
+        # at release time via the develop -> main PR. The Sphinx BUILD step
+        # above remains strict/required; only this commit-back is non-fatal so
+        # the docs workflow stops going red on every develop push.
+        continue-on-error: true
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         run: |
           if [ -n "$(git status --porcelain src/scitex/_sphinx_html)" ]; then


### PR DESCRIPTION
## Problem

The docs workflow (`rtd-sphinx-build-on-ubuntu-latest.yml`) goes red on every `develop` push. The Sphinx build itself is GREEN; the failure is the final "Commit refreshed HTML" step, which does `git push` of the regenerated `src/scitex/_sphinx_html/` bundle to the **protected** `develop` branch. github-actions[bot] cannot push to it, so the push is declined with **GH006 (protected branch hook declined)** and fails the job.

This is workflow infra noise — red across many scitex packages.

## Fix

Add `continue-on-error: true` to **only** the commit-back step. 

- The Sphinx **build** step stays strict/required → build validation is preserved.
- The bundle only needs to be current for production serving, which is refreshed at release time via the `develop -> main` PR — not on every `develop` push.

Single-line change (plus an explanatory comment).

## Notes

- The docs workflow is **not** a required check, so this PR does not block on it.
- This workflow is **hand-maintained per repo** (no scitex-dev template generates the content — only auditors check the bundle's presence). An ecosystem sweep applying the same one-line fix to each package's `rtd-sphinx-build-*.yml` is needed as follow-up.