### PR TITLE
docs: add nbsphinx to [docs] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -810,6 +810,7 @@ docs = [
     "myst-parser>=2.0",
     "sphinx-copybutton>=0.5",
     "sphinx-autodoc-typehints>=1.25",
+    "nbsphinx>=0.9",
 ]
 
 # Development Tools


### PR DESCRIPTION
conf.py loads the `nbsphinx` extension but `[docs]` extras never installed it, so the RTD/sphinx build failed with `No module named 'nbsphinx'`. Add `nbsphinx>=0.9` so the umbrella docs build goes green.