### PR TITLE
fix(re_export): add io to EXTERNAL_REEXPORTS (consistency after #289)

### DIFF
--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -200,6 +200,7 @@ class _CallableModuleWrapper:
 # imports like `from scitex.<short>.<sub> import Y`) resolve to the external
 # package without requiring a `src/scitex/<short>/` directory in this repo.
 EXTERNAL_REEXPORTS = {
+    "io": "scitex_io",  # in-tree dir removed (#289); pure re-export of scitex_io
     # `scitex.ai` was split into the `ml` + `genai` standalones; `ai` is now a
     # deprecated alias handled in __init__.__getattr__ (no `scitex_ai` package).
     "ml": "scitex_ml",


### PR DESCRIPTION
After #289 made `io` a pure external alias (deleted `src/scitex/io/`), `io` was the **only** short declared `external=` in `__init__` but missing from the `EXTERNAL_REEXPORTS` registration map. This one-line fix makes the sets match exactly (29==29) and gives io the same eager LazyLoader pre-registration as its peers (os/str/…). Verified: `scitex.io`/`save`/`scitex.io.bundle` all resolve.