### PR TITLE
chore(deps): drop scitex-core dependency (enable public-archive)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1046,7 +1046,6 @@ all = [
     "scitex[web]",
     "scitex[writer]",
     "scitex[linter]",
-    "scitex[core]",
     "scitex[orochi]",
     "scitex[agent-container]",
     "scitex[dev]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ dependencies = [
     "scitex-notification==0.2.8",
     "scitex-notebook==0.1.2",
     # Delegated modules from #51 standalonization
-    "scitex-core==0.2.8",
     "scitex-db==0.1.11",
     "scitex-scholar==1.4.1",
     "scitex-parallel==0.1.8",
@@ -1056,7 +1055,6 @@ all = [
 # Tool Configurations
 # ============================================
 linter = ["scitex-dev==0.15.0"]
-core = ["scitex-core==0.2.8"]
 orochi = ["scitex-orochi==0.16.3"]
 agent-container = ["scitex-agent-container==0.21.3"]
 

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -303,7 +303,7 @@ _DEFAULT_BRANDED = {
     "tunnel": "scitex_ssh",  # scitex-tunnel merged into scitex-ssh; in-tree dir removed
     "errors": "scitex_logging",  # error taxonomy lives in scitex-logging; in-tree shim removed
     "torch": "scitex_linalg",  # torch numerics (apply_to + nan reductions) live in scitex-linalg
-    "dt": "scitex_datetime",  # legacy short for scitex_core.dt → standalone
+    "dt": "scitex_datetime",  # legacy short for the dt module → standalone scitex-datetime
 }
 
 


### PR DESCRIPTION
scitex-core is the old pre-extraction aggregator; its modules (dict/dt/errors/logging/parallel/path/repro/sh/str/types) are all standalonized. No code imports `scitex_core` — only pyproject deps + a stale re_export.py comment referenced it.

**Changes:**
- Remove `scitex-core==0.2.8` from core deps + the `[core]` extra in pyproject.toml
- Drop the stale `scitex_core.dt` mention in re_export.py (the `dt` alias already targets scitex_datetime)

**Verified:** `import scitex` works (scitex_core isn't even installed) and all formerly-core modules resolve via their standalones.

**Follow-up (noted by lead):** scitex-code and scitex-db still declare scitex-core deps — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)