### PR TITLE
chore(deps): bump scitex-io to 0.2.19 (session track= teardown fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
     "scitex-dev==0.15.0",
-    "scitex-io==0.2.18",
+    "scitex-io==0.2.19",
     "scitex-stats==0.2.23",
     "scitex-audio==0.2.13",
     "scitex-notification==0.2.8",
@@ -374,7 +374,7 @@ git = [
 # IO Module - File I/O operations
 # Use: pip install scitex[io]
 io = [
-    "scitex-io==0.2.18",
+    "scitex-io==0.2.19",
     "h5py",
     "openpyxl",
     "xlrd",
@@ -920,7 +920,7 @@ dev = [
     "scitex-dev==0.15.0",
     "scitex-etc==0.1.10",
     "scitex-genai==0.1.0",
-    "scitex-io==0.2.18",
+    "scitex-io==0.2.19",
     "scitex-notification==0.2.8",
     "scitex-scholar==1.4.1",
     "scitex-ssh==1.0.1",


### PR DESCRIPTION
Bumps the pinned `scitex-io` dependency from `0.2.18` to `0.2.19` (3 occurrences in `pyproject.toml`).

## Why

scitex-io 0.2.19 fixes a BLOCKING bug: `scitex_io.save()` leaked the `track=` control kwarg into the per-format handlers (`_save_pickle`/`_save_yaml` take no extra kwargs), raising `TypeError: _save_pickle() got an unexpected keyword argument 'track'`. This crashed every `stx.session` teardown, which saves CONFIG.pkl/yaml via `scitex_io.save(..., track=False)`, causing scripts to exit non-zero.

Upstream fix: ywatanabe1989/scitex-io#49 (merged). Published to PyPI as scitex-io 0.2.19.

## Changes

- `pyproject.toml`: `scitex-io==0.2.18` → `scitex-io==0.2.19` (×3)