### PR TITLE
chore(deps): pin scitex-session==0.2.1 (clew dogfood figure-save + _load fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -637,6 +637,7 @@ security = []
 # Session Module - Session management
 # Use: pip install scitex[session]
 session = [
+    "scitex-session==0.2.1",
     "matplotlib",
     "PyYAML",
 ]


### PR DESCRIPTION
Bumps the umbrella's pin to **scitex-session==0.2.1**, which fixes two regressions surfaced by scitex-clew dogfooding (`exp session_patterns`):

- **Figure-save (P4_figure):** the injected `plt` now reliably provides the scitex/figrecipe wrapper API (`ax.set_xyt`, …). `scitex-plt` was promoted to a core runtime dependency of scitex-session, so sessions no longer silently degrade to plain pyplot and die with `'Axes' object has no attribute 'set_xyt'`.
- **`_load` shim noise:** `get_debug_mode()` no longer imports the renamed private `scitex_io._load`; it uses the public `scitex_io.load`, removing the `(No module named scitex_io._load)` noise printed at every session start.

scitex-session 0.2.1 is live on PyPI (release PR: ywatanabe1989/scitex-session#15).

The `[session]` extra previously listed only `matplotlib` + `PyYAML`; scitex-session was pulled in transitively (via scitex-scholar / scitex-gen). This adds the explicit pin to match the convention used by the other delegated-module extras.

Leaving for lead to merge.