### PR TITLE
fix(linter): point scitex.linter at scitex_dev.linter (drop archived scitex_linter)

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -154,8 +154,10 @@ events = _LazyModule("events", external="scitex_events")  # Event system
 media = _LazyModule("media")  # Media utilities
 cli = _LazyModule("cli")  # Command-line interface
 linter = _LazyModule(
-    "linter", external="scitex_linter"
-)  # AST-based linter (delegates to scitex-linter)
+    "linter"
+)  # AST-based linter; in-tree linter.py shim delegates to scitex_dev.linter
+# (the `scitex_linter` distribution is an archived re-export shim). The
+# more-consistent scitex.dev.linter resolves to the same engine via dev→scitex_dev.
 clew = _LazyModule(
     "clew", external="scitex_clew"
 )  # Hash-based verification (in-tree dir removed; pure re-export of scitex_clew)

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -210,7 +210,6 @@ EXTERNAL_REEXPORTS = {
     "gen": "scitex_gen",
     "git": "scitex_git",
     "linalg": "scitex_linalg",
-    "linter": "scitex_linter",
     "nn": "scitex_nn",
     "notification": "scitex_notification",
     "pd": "scitex_pd",


### PR DESCRIPTION
## What
`scitex.linter` (and the bare attribute `scitex.linter.X`) were still routing to the **archived** `scitex_linter` distribution, even though an in-tree `src/scitex/linter.py` shim already delegates to the real engine `scitex_dev.linter`. Two stale registrations shadowed that shim:

1. `EXTERNAL_REEXPORTS['linter'] = 'scitex_linter'` — pre-registered `sys.modules['scitex.linter']` to the archived proxy, so `import scitex.linter` never reached the on-disk shim.
2. `linter = _LazyModule('linter', external='scitex_linter')` — made the attribute path (`import scitex; scitex.linter.X` with no explicit submodule import) load the archived package.

## Fix
Drop both stale targets (net **+4 / −3** lines). Now:
- `import scitex.linter` → in-tree shim → `scitex_dev.linter` ✓
- `import scitex; scitex.linter.lint_file` → same shim → `scitex_dev.linter` ✓
- `scitex.dev.linter` (the more-consistent path the lead noted) → same engine via the `dev → scitex_dev` alias ✓
- archived `scitex_linter` is **never imported** on either path ✓

The in-tree shim is kept (it sets the `SCITEX_DEV_LINTER_BRAND`/`_ALIAS` env and curates the public surface). The `scitex_linter.plugins` entry-point group remains accepted for back-compat (deliberate dual-registration, not an import).

## Verified
Both access paths + the dev path resolve to `scitex_dev/linter/__init__.py`; `'scitex_linter' in sys.modules` is `False` after each.