### PR TITLE
fix(umbrella): re-export scitex_session via scitex.session (restore @scitex.session + INJECTED)

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -111,7 +111,9 @@ errors = _LazyModule(
     "errors", external="scitex_logging"
 )  # errors live in scitex-logging
 logging = _LazyModule("logging", external="scitex_logging")
-session = _CallableModuleWrapper("session", main_decorator_name="session")
+session = _CallableModuleWrapper(
+    "session", main_decorator_name="session", external="scitex_session"
+)
 session._setup_persistence("scitex", "session")
 # `module` is an OPTIONAL peer: it proxies the `module` callable from
 # scitex_hub.module (scitex-hub is NOT a hard dep). Callability

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -270,6 +270,7 @@ EXTERNAL_REEXPORTS = {
     "msword": "scitex_msword",
     "os": "scitex_os",
     "security": "scitex_security",
+    "session": "scitex_session",  # @scitex.session decorator + INJECTED sentinel
     "tex": "scitex_tex",
 }
 


### PR DESCRIPTION
## Summary
`scitex.session` was registered as `_CallableModuleWrapper("session", main_decorator_name="session")` without an `external=` peer. Its `_load_module()` therefore fell back to `importlib.import_module(".session", package="scitex")`, which resolved to an empty namespace stub (no `src/scitex/session/` dir on disk + `"session"` missing from `EXTERNAL_REEXPORTS`). Result:

```
AttributeError: module 'scitex.session' has no attribute 'INJECTED'
```

…on every call site that uses the documented entry points: `@scitex.session` decorator, `scitex.session.INJECTED`, and the `scitex.INJECTED` deprecation shim (`scitex/__init__.py` line 214 does `from .session import INJECTED`).

Surfaced 2026-06-06 while debugging the neurovista calc_pac chain on Spartan: `scitex_session` is installed and imports cleanly as a top-level package, but every `scitex.session.*` access blew up.

## Fix
1. `src/scitex/__init__.py:114` — pass `external=\"scitex_session\"` to the `_CallableModuleWrapper`, mirroring how `scitex.module` proxies `scitex_hub.module`.
2. `src/scitex/re_export.py:EXTERNAL_REEXPORTS` — add `\"session\": \"scitex_session\"` so `register_external_lazy_modules()` pre-registers `scitex.session` in `sys.modules` at `import scitex` time.

Net diff: +4 / -1 across two files.

## Test plan
- [x] Local repro before fix: `python -c \"import scitex; scitex.session.INJECTED\"` → AttributeError.
- [ ] After fix in the installed env: same one-liner returns the sentinel, and `@scitex.session def main(): return 0` resolves to `scitex_session.session`.
- [ ] CI green.
- [ ] Downstream neurovista PR #51 (calc_pac → @stx.session migration) becomes runnable against this fix.

## Notes
Restores parity with the documented public API in `scitex/__init__.py` lines 119–137 (the `_CallableModuleWrapper` docstring already advertises `@scitex.session` and `scitex.session.start()` as supported entry points).

The base branch had to be `main` here because `origin/develop` was not present on the remote at the time of PR creation (the repo's release flow auto-deletes develop and recreates it on the next sync). Rebase / retarget to `develop` is fine once it exists.