### PR TITLE
release: sync main with develop (cla.yml secret rename to GH_PERSONAL_ACCESS_TOKEN)

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -111,7 +111,9 @@ errors = _LazyModule(
     "errors", external="scitex_logging"
 )  # errors live in scitex-logging
 logging = _LazyModule("logging", external="scitex_logging")
-session = _CallableModuleWrapper("session", main_decorator_name="session")
+session = _CallableModuleWrapper(
+    "session", main_decorator_name="session", external="scitex_session"
+)
 session._setup_persistence("scitex", "session")
 # `module` is an OPTIONAL peer: it proxies the `module` callable from
 # scitex_hub.module (scitex-hub is NOT a hard dep). Callability

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -270,6 +270,7 @@ EXTERNAL_REEXPORTS = {
     "msword": "scitex_msword",
     "os": "scitex_os",
     "security": "scitex_security",
+    "session": "scitex_session",  # @scitex.session decorator + INJECTED sentinel
     "tex": "scitex_tex",
 }
 


### PR DESCRIPTION
Promotes develop to main so the cla.yml secret rename (`secrets.PERSONAL_ACCESS_TOKEN` / `secrets.CLA_PERSONAL_ACCESS_TOKEN` → `secrets.GH_PERSONAL_ACCESS_TOKEN`) lands on main. Part of the ecosystem-wide PAT secret-name unification — see scitex-dev PR #122 for the PS-168 allowlist context. Once this merges across the 33 affected repos, the lead's god-token sweep deletes the old secret names.