### PR TITLE
chore(deps): bump scitex-io pin to >=0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
     "scitex-dev==0.17.4",
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "scitex-stats==0.2.23",
     "scitex-audio==0.2.13",
     "scitex-notification==0.2.8",
@@ -378,7 +378,7 @@ git = [
 # IO Module - File I/O operations
 # Use: pip install scitex[io]
 io = [
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "h5py",
     "openpyxl",
     "xlrd",
@@ -927,7 +927,7 @@ dev = [
     "scitex-dev==0.17.4",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "scitex-notification==0.2.8",
     "scitex-scholar==1.4.1",
     "scitex-ssh==1.0.1",


### PR DESCRIPTION
## Summary

Bump `scitex-io` pin from `==0.2.20` to `>=0.3.0` in three sites of the umbrella's `pyproject.toml`:

- Line 72 — core `dependencies`
- Line 381 — `[io]` extra
- Line 930 — `[dev]` extra

## Why

`scitex-io v0.3.0` was published to PyPI today carrying three lead-mandated changes that need to reach umbrella consumers:

- **Removed:** silent-fallback `.db` loader stub (scitex-io PR #59) — `stx.io.load("foo.db")` now delegates to `scitex_db.SQLite3` when scitex-db is installed, raises `ValueError` when absent. Umbrella consumers are unaffected because the umbrella core-pins `scitex-db>=0.1.11`, so the dispatch is always active here.
- **Removed + Changed:** silent-empty `load_configs` fallback (scitex-io PR #65) — `load_configs` now raises `ConfigLoadError` naming the offending YAML file and chaining the original exception as `__cause__`. Fixes neurovista's `'DotDict' object has no attribute 'PAC'` symptom by surfacing the real root cause at load time.
- **Fixed:** `apply_debug_values` int-key crash on YAML int keys (scitex-io PR #64) — neurovista's `SEIZURE.yaml` `INT2STR` / `INT2COLOR` tables no longer blow up the debug-promotion walker under `IS_DEBUG=True`.

Pin also relaxes from `==` to `>=` per the ecosystem dependency-pinning rule (`>=` for `scitex-*` deps, `==` only for security) so future scitex-io patch releases reach umbrella users without a coordinated umbrella re-publish every time.

## Test plan

- [ ] CI must pass on the umbrella (sphinx, audit, import-smoke, pytest matrix, CLAssistant — same as scitex-io). The `[dev]` extra installs the bumped scitex-io transitively.
- [ ] No code changes — just pin bump. Behaviour change is surfaced by scitex-io itself; this PR is the umbrella's vehicle for that surface to land in `pip install scitex` users.

## Rollout

This PR is **develop-only** per lead's directive — no umbrella tag/publish without lead's batched-with-hub ping. scitex-code release cadence is gated separately so hub re-verify can land alongside.

## Note on PR target

Develop branch was recreated off `main` at the start of this PR — it had been deleted after PR #314's sync-to-main earlier today. Recreated branch matches PR #314's main content exactly (no drift). The pin bump is the only change.
