### PR TITLE
chore(deps): PS-170 freshness sweep — 5 peer pin bumps (incl scitex-io 0.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
     "scitex-dev>=0.17.6",
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "scitex-stats==0.2.23",
     "scitex-audio==0.2.13",
     "scitex-notification==0.2.8",
@@ -378,7 +378,7 @@ git = [
 # IO Module - File I/O operations
 # Use: pip install scitex[io]
 io = [
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "h5py",
     "openpyxl",
     "xlrd",
@@ -927,7 +927,7 @@ dev = [
     "scitex-dev>=0.17.6",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
-    "scitex-io==0.2.20",
+    "scitex-io>=0.3.0",
     "scitex-notification==0.2.8",
     "scitex-scholar==1.4.1",
     "scitex-ssh==1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,14 +68,14 @@ dependencies = [
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
-    "scitex-dev==0.17.4",
+    "scitex-dev>=0.17.6",
     "scitex-io==0.2.20",
     "scitex-stats==0.2.23",
     "scitex-audio==0.2.13",
     "scitex-notification==0.2.8",
     "scitex-notebook==0.1.2",
     # Delegated modules from #51 standalonization
-    "scitex-db==0.1.11",
+    "scitex-db>=0.1.12",
     "scitex-scholar==1.4.1",
     "scitex-parallel==0.1.8",
     "scitex-types==0.1.6",
@@ -94,7 +94,7 @@ dependencies = [
     "scitex-context==0.1.4",
     "scitex-cv==0.1.5",
     "scitex-introspect==0.1.7",
-    "scitex-msword==0.2.0",
+    "scitex-msword>=0.3.2",
     "scitex-os==0.1.7",
     "scitex-security==0.1.4",
     "scitex-tex==0.1.7",
@@ -263,12 +263,12 @@ cv = [
 db = [
     "sqlalchemy",
     "psycopg2-binary",
-    "scitex-db==0.1.11",
+    "scitex-db>=0.1.12",
 ]
 
 # Dataset Module - Dataset management
 # Use: pip install scitex[dataset]
-dataset = ["scitex-dataset==0.3.10"]
+dataset = ["scitex-dataset>=0.4.0"]
 
 # Datetime Module - Date and time utilities
 # Use: pip install scitex[datetime]
@@ -923,8 +923,8 @@ dev = [
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via
     # `pip install scitex[cloud]` when scitex-hub is available.
     "scitex-container==0.2.1",
-    "scitex-dataset==0.3.10",
-    "scitex-dev==0.17.4",
+    "scitex-dataset>=0.4.0",
+    "scitex-dev>=0.17.6",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
     "scitex-io==0.2.20",
@@ -1060,7 +1060,7 @@ all = [
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev==0.17.4"]
+linter = ["scitex-dev>=0.17.6"]
 orochi = ["scitex-orochi==0.16.4"]
 agent-container = ["scitex-agent-container==0.21.9"]
 


### PR DESCRIPTION
## Summary

PS-170 freshness sweep across **all FIVE** scitex-* peer pins that lag PyPI latest. Consolidated from PR #318 (scitex-io only) + the original 4-peer sweep because the audit's sequential ordering would have failed whichever PR didn't already include the others.

| peer | umbrella pin | PyPI latest | bump |
| --- | --- | --- | --- |
| scitex-io | `==0.2.20` | 0.3.0 | `>=0.3.0` |
| scitex-dev | `==0.17.4` | 0.17.6 | `>=0.17.6` |
| scitex-db | `==0.1.11` | 0.1.12 | `>=0.1.12` |
| scitex-msword | `==0.2.0` | 0.3.2 | `>=0.3.2` |
| scitex-dataset | `==0.3.10` | 0.4.0 | `>=0.4.0` |

## Spot-check verdicts

- **scitex-io 0.2.20 → 0.3.0** — published earlier today carrying **three intentional no-silent-failure antipattern removals**:
  - Removed: silent-fallback `.db` loader stub (scitex-io PR #59) — now delegates to `scitex_db.SQLite3` when present, `ValueError` when `scitex-io[db]` not installed. Umbrella consumers unaffected because the umbrella core-pins `scitex-db>=0.1.12` so the dispatch is always active here.
  - Removed + Changed: silent-empty `load_configs` fallback (scitex-io PR #65) — `load_configs` now raises `ConfigLoadError` naming the offending YAML file and chaining the original exception as `__cause__`. This is the targeted fix neurovista needed.
  - Fixed: `apply_debug_values` int-key crash on YAML int keys (scitex-io PR #64) — neurovista's `SEIZURE.yaml` `INT2STR` / `INT2COLOR` tables no longer blow up the debug-promotion walker under `IS_DEBUG=True`.
- **scitex-dev 0.17.4 → 0.17.6** — patch-level. Safe.
- **scitex-db 0.1.11 → 0.1.12** — the SQLite3 `mode='ro'/timeout=` release explicitly named as the companion to scitex-io PR #59. Safe.
- **scitex-dataset 0.3.10 → 0.4.0** — already in production use in ripple-wm's SIF per lead. Safe.
- **scitex-msword 0.2.0 → 0.3.2** — additive feature work in the track-changes / `<w:trackRevisions/>` XML emission path; verified by `git log v0.2.0..v0.3.1 --oneline` on the standalone and by sanity-checking that the umbrella's only reference is the LazyModule re-export at `src/scitex/__init__.py:134` with no direct API call. Safe.

## Pin relaxation

All 5 bumps relax `==` → `>=` per the ecosystem dependency-pinning rule (`>=` for `scitex-*` deps, `==` reserved for security pins). Lets future peer patch releases reach umbrella users without a coordinated umbrella re-publish every time.

## Test plan

- [ ] CI must pass (sphinx, import-smoke, pytest-matrix incl. the PS-170 audit, CLAssistant, RTD).
- [ ] No code changes — just pin bumps. Behaviour change is surfaced by the peer packages themselves.

## Sites touched

11 lines across `pyproject.toml`:
- Core dependencies: lines 71 (dev), 72 (io), 78 (db), 97 (msword)
- `[db]` extra: line 266
- `[dataset]` extra: line 271
- `[io]` extra: line 381
- `[dev]` extra: lines 926 (dataset), 927 (dev), 930 (io)
- `[linter]` extra: line 1063 (dev)

## Rollout

Develop-only per lead's directive. **NO umbrella tag/publish** — lead gates the umbrella release separately (batched with hub re-verify).

Sequencing after this merges:
- Task #4 (B.2/B.3 ImportError redirect map for the umbrella).
- Task #6 fixes (scitex-gen torch removal, scitex-io mne removal — lead-authorized).

## Note on PR consolidation

This PR was originally opened as a 4-peer sweep (PR #319) with a separate scitex-io PR (#318) layered on top. The audit's sequential-ordering trap surfaced after the first push: whichever PR landed first would leave the other red, because PS-170 audits EVERY stale pin in `pyproject.toml`, not just the diff. Consolidated into this single PR. PR #318 closed as superseded.
