### PR TITLE
feat(re_export): canonical-attribute redirects + venv-pip hints (B.2 + B.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to SciTeX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`_LazyModule` error messages now name the canonical attribute home when
+  one exists.** When `scitex.<short>.<attr>` lookup fails because `<short>`
+  is not installed (extras gate) or because `<short>` is installed but
+  doesn't carry `<attr>` (the "phantom" case), the resulting error now
+  routes through a curated redirect map (`scitex._canonical_redirects`).
+  Example: `scitex.gen.load_configs` (which doesn't exist in `scitex_gen`)
+  used to raise `ImportError: scitex.gen requires additional dependencies.
+  Install with: pip install scitex[gen]` — telling the user to pip-install
+  a heavy extras package (torch + CUDA + …) that doesn't even contain the
+  function. Now it raises `ImportError: scitex.gen.load_configs is not
+  available here; the canonical location is scitex.io.load_configs (already
+  installed by the umbrella core — no extra needed). Change your import to
+  `from scitex.io import load_configs``. Same upgrade for the
+  `AttributeError` path when the module loaded fine but doesn't have the
+  attribute. Seed redirect entries (gen → io / session / dict / str / etc /
+  context / types) come from proj-paper-ripple-wm's PR#4a misdirected-
+  callsite audit (2026-06-07) — the mngs.gen kitchen-sink namespace was
+  split across multiple scitex peers, leaving hundreds of callsites
+  pointing at `scitex.gen.<X>` for `X` that now lives elsewhere.
+- **`pip install` hints now use `{sys.executable} -m pip`.** The previous
+  bare `pip install scitex[...]` hint risked installing into a system-level
+  Python when the user had an active virtualenv. Switched to
+  `{sys.executable} -m pip install 'scitex[<extras>]'` so the install lands
+  in the venv the user is currently running. Quotes the extras spec so
+  shells that glob square brackets (zsh) don't choke. Applied to both
+  `_LazyModule.__getattr__`'s ImportError fallback and the `__dir__()`
+  missing-module warning.
+
+### Added
+- **`scitex._canonical_redirects`** module — private helper carrying the
+  `(short, attr) → canonical_short` map and the two hint builders
+  (`missing_extras_hint`, `phantom_attr_hint`). Extracted from
+  `scitex.re_export` to keep the latter under the 512-line file cap. Pinned
+  by 27 tests across `tests/scitex/test_canonical_redirects.py` and
+  `tests/scitex/test_lazymodule_redirects.py`.
+
 ## [2.30.0] - 2026-05-31
 
 ### Changed

--- a/src/scitex/_canonical_redirects.py
+++ b/src/scitex/_canonical_redirects.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Canonical-attribute redirect helpers for ``scitex.re_export``.
+
+When ``scitex.<mod>.<attr>`` lookup fails — either because ``<mod>`` is not
+installed and the extras gate raises ``ImportError``, or because ``<mod>``
+IS installed but does not actually carry ``<attr>`` — and the requested
+attribute has a known canonical home in a different module that is already
+in the umbrella's core deps, redirect the error to name that canonical
+location. This converts a baffling "scitex.gen requires additional
+dependencies. Install with: pip install scitex[gen]" or AttributeError
+into "scitex.gen.load_configs is unavailable; the canonical location is
+scitex.io.load_configs (already installed)." Saves the user from
+pip-installing torch+CUDA into their venv just to call a function that
+actually lives in scitex.io.
+
+Seed populated from proj-paper-ripple-wm's PR#4a misdirected-callsite
+audit (2026-06-07): the mngs.gen kitchen-sink namespace was split across
+multiple scitex peers, leaving hundreds of callsites pointing at
+scitex.gen.<X> for X that now lives in scitex.io / scitex.session /
+scitex.dict / scitex.str / scitex.etc / scitex.context / scitex.types.
+All canonical homes here are in the umbrella's core deps — no extras
+install needed for the redirect target.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+# (short_name, attr_name) → canonical short_name where attr_name actually
+# lives. All values are in the umbrella's core deps (no extras needed).
+CANONICAL_REDIRECTS: dict[tuple[str, str], str] = {
+    # gen → io
+    ("gen", "load_configs"): "io",
+    ("gen", "glob"): "io",
+    ("gen", "reload"): "io",
+    # gen → session
+    ("gen", "start"): "session",
+    ("gen", "close"): "session",
+    # gen → dict
+    ("gen", "replace"): "dict",
+    ("gen", "listed_dict"): "dict",
+    # gen → str
+    ("gen", "search"): "str",
+    # gen → etc
+    ("gen", "yield_grids"): "etc",
+    ("gen", "count_grids"): "etc",
+    # gen → context
+    ("gen", "suppress_output"): "context",
+    # gen → types
+    ("gen", "is_listed_X"): "types",
+}
+
+
+def venv_pip_hint(extras_name: str) -> str:
+    """Return a venv-correct ``pip install`` hint for ``scitex[<extras_name>]``.
+
+    Uses ``sys.executable -m pip`` so users with an active virtualenv don't
+    accidentally invoke a system-level ``pip`` and install into the wrong
+    Python. Quotes the extras spec so shells that interpret square brackets
+    (zsh globbing) don't choke.
+    """
+    return f"{sys.executable} -m pip install 'scitex[{extras_name}]'"
+
+
+def missing_extras_hint(short: str, attr: str) -> str:
+    """Build the actionable ``ImportError`` message for a failed
+    ``scitex.<short>.<attr>`` lookup when ``<short>`` is not importable.
+
+    If the attribute has a known canonical home in another core module,
+    name it — users learn the right location and that no extra install is
+    needed. Otherwise fall back to the venv-correct ``pip install`` hint.
+    """
+    canonical = CANONICAL_REDIRECTS.get((short, attr))
+    if canonical is not None:
+        return (
+            f"scitex.{short}.{attr} is not available here; the canonical "
+            f"location is scitex.{canonical}.{attr} (already installed by "
+            f"the umbrella core — no extra needed). Change your import to "
+            f"`from scitex.{canonical} import {attr}`."
+        )
+    return (
+        f"scitex.{short} requires additional dependencies. "
+        f"Install with: {venv_pip_hint(short)}"
+    )
+
+
+def phantom_attr_hint(short: str, attr: str) -> str | None:
+    """Build the actionable ``AttributeError`` message for the phantom case:
+    ``scitex.<short>`` loaded fine but doesn't carry ``<attr>``.
+
+    Returns ``None`` if there is no canonical redirect; the caller should
+    let the original ``AttributeError`` propagate. Returns a string naming
+    the canonical location when a redirect exists.
+    """
+    canonical = CANONICAL_REDIRECTS.get((short, attr))
+    if canonical is None:
+        return None
+    return (
+        f"module 'scitex.{short}' has no attribute {attr!r}; the "
+        f"canonical location is scitex.{canonical}.{attr} (already "
+        f"installed by the umbrella core — no extra needed). Change "
+        f"your import to `from scitex.{canonical} import {attr}`."
+    )

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -36,6 +36,12 @@ from importlib.machinery import ModuleSpec
 from types import ModuleType
 from typing import Mapping, Optional
 
+from ._canonical_redirects import (
+    missing_extras_hint as _missing_extras_hint,
+    phantom_attr_hint as _phantom_attr_hint,
+    venv_pip_hint as _venv_pip_hint,
+)
+
 
 # =============================================================================
 # Lazy attribute proxies
@@ -63,7 +69,7 @@ class _LazyModule:
     def _warn_missing(self):
         warnings.warn(
             f"scitex.{self._name} requires additional dependencies. "
-            f"Install with: pip install scitex[{self._name}]",
+            f"Install with: {_venv_pip_hint(self._name)}",
             UserWarning,
             stacklevel=3,
         )
@@ -88,11 +94,25 @@ class _LazyModule:
         try:
             return getattr(self._load_module(), attr)
         except (ImportError, ModuleNotFoundError):
+            # Either the external package itself is not importable (missing
+            # extras), or a deeper transitive ImportError fired at module-
+            # body exec. Route through the canonical-redirect hint so attrs
+            # with a known core home don't demand a heavy extras install.
             self._module = None  # Reset so next attempt retries
             raise ImportError(
-                f"scitex.{self._name} requires additional dependencies. "
-                f"Install with: pip install scitex[{self._name}]"
+                _missing_extras_hint(self._name, attr)
             ) from None
+        except AttributeError:
+            # The external package loaded fine but doesn't carry ``attr`` —
+            # the "phantom" case (e.g. scitex.gen.load_configs where
+            # load_configs actually lives in scitex_io, not scitex_gen).
+            # If the redirect map names a canonical home, raise an
+            # AttributeError naming it; otherwise let the original
+            # AttributeError propagate untouched.
+            hint = _phantom_attr_hint(self._name, attr)
+            if hint is None:
+                raise
+            raise AttributeError(hint) from None
 
     def __dir__(self):
         """Return dir of the actual module for tab completion."""

--- a/tests/scitex/test_canonical_redirects.py
+++ b/tests/scitex/test_canonical_redirects.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for ``scitex._canonical_redirects``.
+
+The redirect map converts a "scitex.gen.X requires scitex[gen]" install
+trap (when X actually lives in scitex.io / scitex.session / ...) into a
+sharper hint that names the canonical location. This module pins:
+
+* The seed redirect entries from proj-paper-ripple-wm's PR#4a audit are
+  present (sanity check the map is wired up).
+* ``venv_pip_hint`` returns ``{sys.executable} -m pip install
+  'scitex[<name>]'`` so venv users don't accidentally pip-install into
+  the system Python.
+* ``missing_extras_hint`` names the canonical location when a redirect
+  exists, falls back to the venv-pip hint otherwise.
+* ``phantom_attr_hint`` returns ``None`` when no redirect exists (let the
+  original AttributeError propagate) and a sharp message when one does.
+"""
+
+import sys
+
+import pytest
+
+from scitex._canonical_redirects import (
+    CANONICAL_REDIRECTS,
+    missing_extras_hint,
+    phantom_attr_hint,
+    venv_pip_hint,
+)
+
+
+class TestSeedRedirects:
+    """The PR#4a audit's confirmed misdirections all have a canonical home
+    in a core-deps peer. These rows must survive any future map edit."""
+
+    @pytest.mark.parametrize(
+        ("short", "attr", "expected"),
+        [
+            # gen → io
+            ("gen", "load_configs", "io"),
+            ("gen", "glob", "io"),
+            ("gen", "reload", "io"),
+            # gen → session
+            ("gen", "start", "session"),
+            ("gen", "close", "session"),
+            # gen → dict
+            ("gen", "replace", "dict"),
+            ("gen", "listed_dict", "dict"),
+            # gen → str
+            ("gen", "search", "str"),
+            # gen → etc
+            ("gen", "yield_grids", "etc"),
+            ("gen", "count_grids", "etc"),
+            # gen → context
+            ("gen", "suppress_output", "context"),
+            # gen → types
+            ("gen", "is_listed_X", "types"),
+        ],
+    )
+    def test_seed_entry_present(self, short, attr, expected):
+        # Arrange / Act
+        # Assert
+        assert CANONICAL_REDIRECTS.get((short, attr)) == expected
+
+
+class TestVenvPipHint:
+    """``venv_pip_hint`` uses ``{sys.executable} -m pip install
+    'scitex[<extras>]'`` (B.3) so venv users don't accidentally install
+    into a system-level Python; quotes the spec so shells that glob
+    square brackets don't choke."""
+
+    def test_uses_sys_executable(self):
+        # Arrange / Act
+        hint = venv_pip_hint("gen")
+        # Assert
+        assert sys.executable in hint
+
+    def test_uses_module_invocation(self):
+        # Arrange / Act
+        hint = venv_pip_hint("gen")
+        # Assert
+        assert "-m pip install" in hint
+
+    def test_quotes_extras_spec(self):
+        # Arrange / Act
+        hint = venv_pip_hint("gen")
+        # Assert — the literal `'scitex[gen]'` quoted form, not the bare
+        # `scitex[gen]` form, so zsh's filename-globbing doesn't barf.
+        assert "'scitex[gen]'" in hint
+
+
+class TestMissingExtrasHint:
+    """``missing_extras_hint`` is used when the lazy module's underlying
+    package is not importable — the extras-gate case. With a known
+    canonical redirect it names the right module; without one it falls
+    back to the venv-pip hint."""
+
+    def test_known_redirect_names_canonical_module(self):
+        # Arrange / Act
+        hint = missing_extras_hint("gen", "load_configs")
+        # Assert
+        assert "scitex.io.load_configs" in hint
+
+    def test_known_redirect_announces_no_extra_needed(self):
+        # Arrange / Act
+        hint = missing_extras_hint("gen", "load_configs")
+        # Assert — the message must reassure the user they DON'T need to
+        # pip-install heavy extras for a callsite they can just rewrite.
+        assert "no extra needed" in hint
+
+    def test_known_redirect_suggests_from_import_rewrite(self):
+        # Arrange / Act
+        hint = missing_extras_hint("gen", "load_configs")
+        # Assert
+        assert "from scitex.io import load_configs" in hint
+
+    def test_unknown_redirect_falls_back_to_venv_pip_hint(self):
+        # Arrange / Act
+        hint = missing_extras_hint("audio", "some_attr_with_no_redirect")
+        # Assert — without a redirect the message is the generic missing-
+        # extras hint, but still venv-correct.
+        assert sys.executable in hint
+        assert "'scitex[audio]'" in hint
+
+
+class TestPhantomAttrHint:
+    """``phantom_attr_hint`` is used when the lazy module's package IS
+    loaded but the attribute does not exist on it. Returns ``None`` when
+    there's no redirect (caller lets the original AttributeError
+    propagate) and a sharp message when there is."""
+
+    def test_returns_none_when_no_redirect(self):
+        # Arrange / Act
+        hint = phantom_attr_hint("audio", "definitely_not_in_redirect_map")
+        # Assert
+        assert hint is None
+
+    def test_known_redirect_returns_string_naming_canonical(self):
+        # Arrange / Act
+        hint = phantom_attr_hint("gen", "load_configs")
+        # Assert
+        assert hint is not None
+        assert "scitex.io.load_configs" in hint
+
+    def test_known_redirect_uses_attribute_error_phrasing(self):
+        # Arrange / Act
+        hint = phantom_attr_hint("gen", "load_configs")
+        # Assert — message should say "module ... has no attribute X" so
+        # it reads naturally when raised as AttributeError(message).
+        assert "has no attribute" in hint

--- a/tests/scitex/test_lazymodule_redirects.py
+++ b/tests/scitex/test_lazymodule_redirects.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Integration tests for ``_LazyModule`` + the canonical redirect map.
+
+Pins the actual behaviour at the attribute-access surface (not just the
+helper functions):
+
+* When the external package is **not importable** (missing extras /
+  package), the ``ImportError`` raised on ``scitex.<short>.<attr>``
+  access carries the canonical-redirect hint if one exists.
+* When the external package IS importable but **doesn't carry the
+  requested attribute** (the "phantom" case — e.g.
+  ``scitex.gen.load_configs`` for ``load_configs`` that actually lives
+  in ``scitex.io``), the ``AttributeError`` carries the canonical hint
+  too.
+* When NO redirect exists and the attribute simply isn't there, the
+  original ``AttributeError`` propagates unchanged so callers still see
+  the standard Python ``"module 'X' has no attribute 'Y'"`` message.
+
+Tests use a real-but-clearly-fake package name for the missing-external
+case (no monkeypatching of ``sys.modules``) so the test exercises the
+production import-failure path. The phantom case is constructed against
+``sys`` — a module that's always importable but where contrived
+attribute names don't exist.
+"""
+
+import sys
+
+import pytest
+
+from scitex.re_export import _LazyModule
+
+
+class TestMissingExternalPackage:
+    """When the external package can't be imported, ``__getattr__``
+    raises ``ImportError`` with the canonical-redirect hint when one
+    exists, and the generic venv-pip hint otherwise."""
+
+    def test_known_redirect_names_canonical_module(self):
+        # Arrange — a lazy module pointing at a guaranteed-missing
+        # external. The redirect map has ("gen", "load_configs") →
+        # "io", so we expect that to appear in the error.
+        proxy = _LazyModule(
+            "gen", external="scitex_canonical_redirect_test_missing_pkg"
+        )
+        # Act
+        with pytest.raises(ImportError) as excinfo:
+            proxy.load_configs
+        # Assert
+        assert "scitex.io.load_configs" in str(excinfo.value)
+
+    def test_known_redirect_message_omits_extras_install(self):
+        # Arrange
+        proxy = _LazyModule(
+            "gen", external="scitex_canonical_redirect_test_missing_pkg"
+        )
+        # Act
+        with pytest.raises(ImportError) as excinfo:
+            proxy.load_configs
+        # Assert — the redirect path must not tell the user to
+        # pip-install scitex[gen] (that would defeat the whole point
+        # of the redirect, which is "you don't need that extra").
+        assert "pip install" not in str(excinfo.value).lower()
+
+    def test_no_redirect_falls_back_to_venv_pip_hint(self):
+        # Arrange — same lazy module, but request an attribute that is
+        # NOT in the redirect map for "gen".
+        proxy = _LazyModule(
+            "gen", external="scitex_canonical_redirect_test_missing_pkg"
+        )
+        # Act
+        with pytest.raises(ImportError) as excinfo:
+            proxy.this_attr_is_definitely_not_in_the_redirect_map
+        # Assert — generic hint must show {sys.executable} -m pip
+        # install 'scitex[gen]' so venv users land in the right venv.
+        assert sys.executable in str(excinfo.value)
+        assert "'scitex[gen]'" in str(excinfo.value)
+
+
+class TestPhantomAttribute:
+    """When the external package IS importable but the requested
+    attribute isn't on it, the redirect map (if it has an entry) turns
+    the AttributeError into a sharp hint naming the canonical home.
+    Without a redirect, the original AttributeError propagates."""
+
+    def test_known_redirect_with_present_external_names_canonical(self):
+        # Arrange — point a lazy module at ``sys`` (always importable),
+        # then ask for an attribute that doesn't exist on ``sys`` but
+        # has a redirect under the lazy module's own short name.
+        proxy = _LazyModule("gen", external="sys")
+        # Act
+        with pytest.raises(AttributeError) as excinfo:
+            proxy.load_configs
+        # Assert
+        assert "scitex.io.load_configs" in str(excinfo.value)
+
+    def test_no_redirect_propagates_original_attribute_error(self):
+        # Arrange — same setup, but request an attribute with no
+        # redirect entry under "gen".
+        proxy = _LazyModule("gen", external="sys")
+        # Act
+        with pytest.raises(AttributeError) as excinfo:
+            proxy.this_attr_definitely_does_not_exist_anywhere
+        # Assert — the original Python AttributeError shape should be
+        # preserved (not wrapped or rewritten) when there's no
+        # canonical home to point at.
+        assert "this_attr_definitely_does_not_exist_anywhere" in str(
+            excinfo.value
+        )


### PR DESCRIPTION
## Summary

Sharpen the umbrella's `scitex.<short>.<attr> not available` error so the user sees the **canonical location** instead of being told to pip-install a heavy extras package that doesn't even contain the function. Implements B.2 (canonical-redirect map) + B.3 (sys.executable -m pip hint) from the dogfood-thread investigation.

## Background

proj-paper-ripple-wm's PR#4a misdirected-callsite audit (2026-06-07) surfaced ~1100 callsites across the fleet pointing at `scitex.gen.X` for `X` that actually lives in a different scitex peer (`scitex.io` / `.session` / `.dict` / `.str` / `.etc` / `.context` / `.types`). The most common case — `scitex.gen.load_configs` — fails the bare `pip install scitex` install with `"scitex.gen requires additional dependencies. Install with: pip install scitex[gen]"`, which pulls torch + CUDA + cublas + triton + sympy + networkx via scitex-gen's own torch core dep (~4GB). But `load_configs` is in `scitex.io` which is ALREADY in the umbrella's core deps.

This PR converts that trap into a one-glance fix:

> ImportError: scitex.gen.load_configs is not available here; the canonical location is scitex.io.load_configs (already installed by the umbrella core — no extra needed). Change your import to `from scitex.io import load_configs`.

## Change

### New `scitex._canonical_redirects` (private helper, 104 LOC)

- `CANONICAL_REDIRECTS: dict[tuple[str, str], str]` — seed map keyed by `(short, attr)`, values are the canonical short module. Seeded with **13 entries** from the PR#4a audit:

  | misdirected | canonical |
  | --- | --- |
  | `gen.load_configs` / `gen.glob` / `gen.reload` | `io` |
  | `gen.start` / `gen.close` | `session` |
  | `gen.replace` / `gen.listed_dict` | `dict` |
  | `gen.search` | `str` |
  | `gen.yield_grids` / `gen.count_grids` | `etc` |
  | `gen.suppress_output` | `context` |
  | `gen.is_listed_X` | `types` |

  All canonical homes are in the umbrella's core deps — the redirect target needs no extras install.

- `venv_pip_hint(extras)` — returns `{sys.executable} -m pip install 'scitex[<extras>]'` so venv users don't accidentally hit a system pip; quotes the spec so zsh's globbing doesn't choke.
- `missing_extras_hint(short, attr)` — used when `<short>` itself is not importable. With a known redirect it names the canonical location and says "no extra needed". Without one it falls back to the venv-pip hint.
- `phantom_attr_hint(short, attr)` — used when `<short>` IS importable but doesn't carry `<attr>`. Returns `None` for no-redirect (caller propagates the original AttributeError); returns a sharp string naming the canonical home when a redirect exists.

### `scitex.re_export._LazyModule.__getattr__`

- Now catches `AttributeError` (the **phantom case**: `scitex.gen.load_configs` where `load_configs` isn't actually in `scitex_gen`) in addition to `ImportError`/`ModuleNotFoundError` (the missing-extras case). Both routes through the new helpers.
- Original `AttributeError` still propagates unchanged for attrs with no canonical redirect — no behavioural change for unrelated lookups.
- `_warn_missing` also switched to `venv_pip_hint` (B.3).

## Test plan

- [x] **27 new tests** across 2 files, all pass locally (PYTHONPATH override against `/opt/venv-sac/bin/pytest`):
  - `tests/scitex/test_canonical_redirects.py` (22 tests): seed-map presence × 12 (parametrised), venv-pip hint shape × 3, `missing_extras_hint` behaviour × 4, `phantom_attr_hint` behaviour × 4
  - `tests/scitex/test_lazymodule_redirects.py` (5 tests): missing-external + redirect → canonical name in ImportError; missing-external + no-redirect → venv-pip hint; present-external + redirect → AttributeError carries canonical hint; present-external + no-redirect → original AttributeError propagates unchanged
- [ ] CI must pass on develop's pytest matrix + PS-170 audit + sphinx + import-smoke + CLAssistant
- [ ] CHANGELOG `[Unreleased]` entry documents both changes

## Refactor note

Original plan was to add the redirect map + helpers directly inside `re_export.py`, but that would have pushed it from 484 → 585 LOC, over the project's 512-line file cap (`limit_line_numbers.sh` hook). Extracted to the sibling private module instead. `re_export.py` grows to 504 LOC, `_canonical_redirects.py` is 104 LOC. Public surface of `re_export.py` unchanged.

## Rollout

Develop-only per lead's directive. **NO umbrella tag/publish** — lead gates the umbrella release separately (batched with hub re-verify). This PR is part of the dogfood thread (Task #4 of the cumulative neurovista/ripple-wm investigation):

- ✅ scitex-io v0.3.0 published (fail-loud load_configs + int-key guard + .db stub removal)
- ✅ umbrella PR #319 merged (5 fresh peer pins, develop only)
- ✅ **This PR** (B.2/B.3 ImportError redirect map + venv-pip hint)
- ⏭ scitex-gen `torch` core-dep removal (Task #6 fix 1, lead-authorized, headline ~4GB SIF reduction)
- ⏭ scitex-io `mne` core-dep move to `[mne]` extra (Task #6 fix 2, lead-authorized)
