### PR TITLE
feat(pyproject): regen [all] aggregator + per-module extras from ECOSYSTEM SSoT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,16 +180,41 @@ benchmark = [
     "psutil",
 ]
 
-# Bridge Module - External system integration
-# Use: pip install scitex[bridge]
-bridge = [
-    "matplotlib",
-    "scipy",
-]
-
 # Container Module - Unified container management (Apptainer + Docker)
 # Use: pip install scitex[container]
 container = ["scitex-container==0.2.1"]
+
+# Core Module - Core infrastructure / fundamental utilities
+# Use: pip install scitex[core]
+core = ["scitex-core==0.2.8"]
+
+# HPC Module - High-performance / cluster utilities
+# Use: pip install scitex[hpc]
+hpc = ["scitex-hpc==0.8.1"]
+
+# Math Module - Mathematical utilities (parity helpers, etc.)
+# Use: pip install scitex[math]
+math = ["scitex-math==0.1.0"]
+
+# Newb Module - newb peer (external-lib brand)
+# Use: pip install scitex[newb]
+newb = ["newb==0.26.7"]
+
+# REPL Module - Interactive REPL helpers (embed, less, paste)
+# Use: pip install scitex[repl]
+repl = ["scitex-repl==0.1.1"]
+
+# Seizure-Metrics Module - Epilepsy seizure-detection metrics
+# Use: pip install scitex[seizure-metrics]
+seizure-metrics = ["scitex-seizure-metrics==0.1.3"]
+
+# SSH Module - SSH client + reverse tunnel
+# Use: pip install scitex[ssh]
+ssh = ["scitex-ssh==1.0.1"]
+
+# Todo Module - Task / todo utilities
+# Use: pip install scitex[todo]
+todo = ["scitex-todo==0.3.0"]
 
 # Browser Module - Web automation
 # Use: pip install scitex[browser]
@@ -979,71 +1004,77 @@ dev = [
 # Auto-aggregates all individual module extras via self-referencing.
 # When adding a new module extras group, add a corresponding entry here.
 all = [
-    "scitex[ml]",
-    "scitex[genai]",
+    "scitex[agent-container]",
     "scitex[app]",
     "scitex[audio]",
     "scitex[audit]",
-    "scitex[docs]",
     "scitex[benchmark]",
-    "scitex[bridge]",
     "scitex[browser]",
     "scitex[capture]",
     "scitex[clew]",
     "scitex[cli]",
-    # NOTE: scitex[cloud] / scitex[module] / scitex[project] (scitex-hub) are
-    # OPTIONAL peers deliberately kept OUT of [all] so CI's matrix runs without
-    # the unreleased scitex-hub. Install explicitly: pip install scitex[cloud].
     "scitex[compat]",
     "scitex[config]",
     "scitex[container]",
     "scitex[context]",
+    "scitex[core]",
     "scitex[cv]",
     "scitex[dataset]",
-    "scitex[db]",
     "scitex[datetime]",
+    "scitex[db]",
     "scitex[decorators]",
+    "scitex[dev]",
     "scitex[devtools]",
     "scitex[diagram]",
     "scitex[dict]",
+    "scitex[docs]",
     "scitex[dsp]",
     "scitex[dt]",
     "scitex[etc]",
     "scitex[events]",
     "scitex[gen]",
+    "scitex[genai]",
     "scitex[gists]",
     "scitex[git]",
     "scitex[heavy]",
+    "scitex[hpc]",
     "scitex[introspect]",
     "scitex[io]",
     "scitex[linalg]",
     "scitex[logging]",
+    "scitex[math]",
     "scitex[media]",
     "scitex[ml]",
     "scitex[msword]",
+    "scitex[newb]",
     "scitex[nn]",
     "scitex[notebook]",
     "scitex[notification]",
+    "scitex[orochi]",
     "scitex[os]",
     "scitex[parallel]",
     "scitex[path]",
     "scitex[pd]",
     "scitex[plt]",
+    "scitex[repl]",
     "scitex[repro]",
     "scitex[reproduce]",
     "scitex[resource]",
     "scitex[rng]",
     "scitex[schema]",
-    "scitex[scholar]",
     "scitex[scholar-gui]",
+    "scitex[scholar]",
     "scitex[security]",
+    "scitex[seizure-metrics]",
     "scitex[session]",
     "scitex[sh]",
     "scitex[social]",
+    "scitex[ssh]",
     "scitex[stats]",
     "scitex[str]",
     "scitex[template]",
     "scitex[tex]",
+    "scitex[todo]",
     "scitex[torch]",
     "scitex[tunnel]",
     "scitex[types]",
@@ -1051,16 +1082,11 @@ all = [
     "scitex[verify]",
     "scitex[web]",
     "scitex[writer]",
-    "scitex[linter]",
-    "scitex[orochi]",
-    "scitex[agent-container]",
-    "scitex[dev]",
 ]
 
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev>=0.17.6"]
 orochi = ["scitex-orochi==0.16.4"]
 agent-container = ["scitex-agent-container==0.21.9"]
 


### PR DESCRIPTION
## Summary

This is **PR-B** — the umbrella half of the ECOSYSTEM SSoT promotion the
operator approved this morning (2026-06-07). Driven mechanically by
\`scitex-dev ecosystem audit-umbrella --write\` (scitex-dev v0.17.6+ — see
[scitex-dev PR-A #134](https://github.com/ywatanabe1989/scitex-dev/pull/134)
and [PR-A2 #136](https://github.com/ywatanabe1989/scitex-dev/pull/136))
plus a hand-applied per-extra group block for the 8 packages that didn't
yet have one.

### ADDED to \`[all]\` aggregator (7 new + 1 misplaced):

| Extra | Driven by |
|-------|----------|
| \`scitex[core]\` | scitex-core (added to ECOSYSTEM in scitex-dev #133) |
| \`scitex[hpc]\` | scitex-hpc (in registry, never wired) |
| \`scitex[math]\` | scitex-math (added in #133) |
| \`scitex[newb]\` | newb peer (in registry, never wired) |
| \`scitex[repl]\` | scitex-repl (added in scitex-dev #135) |
| \`scitex[seizure-metrics]\` | scitex-seizure-metrics (never wired) |
| \`scitex[ssh]\` | scitex-ssh (never wired) |
| \`scitex[todo]\` | scitex-todo (never wired) |

Plus \`scitex[agent-container]\` (was at the end of the old \`[all]\`; tomlkit
re-sorts the whole array so the diff shows it as "moved").

### REMOVED from \`[all]\` (both archived peers):

- \`scitex[bridge]\` — scitex-bridge (cross-module adapter shim,
  superseded by inline integration in scitex-stats / scitex-plt)
- \`scitex[linter]\` — scitex-linter (AST rules folded into scitex-dev
  >=0.16.0)

### NEW per-module \`[<extra>] = ["scitex-<X>==<version>"]\` groups:

\`\`\`toml
core = ["scitex-core==0.2.8"]
hpc = ["scitex-hpc==0.8.1"]
math = ["scitex-math==0.1.0"]
newb = ["newb==0.26.7"]
repl = ["scitex-repl==0.1.1"]
seizure-metrics = ["scitex-seizure-metrics==0.1.3"]
ssh = ["scitex-ssh==1.0.1"]
todo = ["scitex-todo==0.3.0"]
\`\`\`

(versions sourced from the latest PyPI release of each peer; bump as
needed during the release-wave coordination)

### DROPPED extra groups:

- \`bridge = ["matplotlib", "scipy"]\`
- \`linter = ["scitex-dev>=0.17.6"]\`

### Operator policy preserved

\`scitex[cloud]\` / \`scitex[hub]\` / \`scitex[module]\` / \`scitex[project]\`
(all scitex-hub-powered optional peers) stay OUT of \`[all]\` so
\`pip install scitex[all]\` resolves without scitex-hub being released.
The inline comment that explained this convention was lost by tomlkit's
array rewrite; happy to re-add it manually if you want it back.

### Scope NOT in this PR

The companion \`src/scitex/__init__.py\` lazy_attr declarations (14 new)
and \`src/scitex/re_export.py\` EXTERNAL_REEXPORTS entries (18 new) for
the same packages need marker-based regen — that lands in **PR-A3 in
scitex-dev** first (adds marker-based --write to \`audit-umbrella\`),
then a PR-B2 here picks up the regenerated Python sources. Until then:

- \`pip install scitex[core]\` etc. WILL install the peer (this PR
  enables it).
- \`import scitex.core\` via attribute access on the umbrella will
  resolve through the existing \`alias_finder\` if the peer is
  installed, BUT no eager \`<short> = _LazyModule(...)\` declaration
  exists yet in \`__init__.py\` — so \`scitex.core\` shows up via
  \`__getattr__\` not as a sticky attribute. Functionally fine for
  most consumer patterns; PR-B2 makes them first-class.

## Test plan

- [x] \`tomllib.loads(pyproject_text)\` parses cleanly.
- [x] No new findings from scitex-dev v0.17.6+'s REL-50 umbrella
      SSoT-drift auditor (the new rule that fails CI on this exact
      kind of drift) — verified by running
      \`scitex-dev ecosystem audit-umbrella --check\` against
      this branch's checkout: \`[all]\` aggregator reports \`(no drift)\`.
- [ ] CI: full test matrix.
- [ ] Operator review on the lost cloud/module/project policy comment.

## Sequencing

Drives umbrella v2.30.1 → next patch release (version bump deferred to
release-wave coordinator). Hub-prod is already on a clean recovery path
(Dockerfile-side fix per the 2026-06-07 triage).