### PR TITLE
feat(umbrella): repoint scitex.security to scitex_audit.github (ADR-0001 W1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to SciTeX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`scitex.security` repointed to `scitex_audit.github`** per ADR-0001
+  (scitex-dev #139, Accepted 2026-06-07). `scitex-security` was absorbed
+  into `scitex-audit` 0.2.0; the 5 public symbols (`check_github_alerts`,
+  `save_alerts_to_file`, `get_latest_alerts_file`, `format_alerts_report`,
+  `GitHubSecurityError`) now live in `scitex_audit.github`. The umbrella
+  `_LazyModule("security", external="scitex_audit.github")` resolution
+  + the `external_alias_map` "security" entry both move atomically.
+- **`[security]` extra** now installs `scitex-audit>=0.2.0` (was empty).
+  Brings the umbrella extras into compliance with skill 03 §8 "every
+  module MUST have an extra listing its standalone package".
+- **`scitex-audit` pinned to `==0.2.0`** in main deps, `[audit]`,
+  `[dev]`, and `[all]`.
+
+### Removed
+- **`scitex-security==0.1.4`** from main deps and `[all]` — absorbed
+  into `scitex-audit`. The deprecated `scitex-security` 0.2.0 PyPI
+  shim is NOT pulled by the umbrella; users who explicitly depend on
+  the old package still get a `DeprecationWarning` redirecting them
+  to `scitex_audit.github`.
+
+### Migration
+- `from scitex_security import X` → `from scitex_audit.github import X`,
+  or just `scitex.security.X` (now resolves to the same SSOT).
+- `scitex-security check OWNER/REPO --save` → `scitex-audit github
+  --repo OWNER/REPO --save`. The legacy console-script hard-errors
+  with a redirect per CLI-deprecation skill 11 §5.
+- `~/.scitex/security/` auto-symlinks to `~/.scitex/audit/github-alerts/`
+  on first import of `scitex_audit` (one-shot, marker-gated).
+
 ## [2.30.0] - 2026-05-31
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "scitex-etc==0.2.0",  # media shipped here; scitex.media re-exports scitex_etc.media
     "scitex-genai==0.1.0",
     "scitex-gists==0.1.7",
-    "scitex-audit==0.1.7",
+    "scitex-audit==0.2.0",
     "scitex-logging==0.1.7",
     "scitex-dict==0.1.7",
     "scitex-browser==0.1.15",
@@ -96,7 +96,10 @@ dependencies = [
     "scitex-introspect==0.1.7",
     "scitex-msword==0.2.0",
     "scitex-os==0.1.7",
-    "scitex-security==0.1.4",
+    # scitex-security DROPPED here per ADR-0001 (scitex-dev #139) —
+    # absorbed into scitex-audit. The [security] extra now installs
+    # scitex-audit; scitex-python's main deps no longer pull the
+    # deprecated 0.1.4 standalone.
     "scitex-tex==0.1.7",
     "figrecipe==0.28.20",
     "scitex-ui==0.5.1",
@@ -172,7 +175,7 @@ audio = [
 
 # Audit Module - Code and security auditing
 # Use: pip install scitex[audit]
-audit = ["scitex-audit==0.1.7"]
+audit = ["scitex-audit==0.2.0"]
 
 # Benchmark Module - Performance monitoring
 # Use: pip install scitex[benchmark]
@@ -638,9 +641,13 @@ scholar = [
 # Use: pip install scitex[schema]
 schema = []
 
-# Security Module - Security utilities
+# Security Module - Security utilities. Absorbed into scitex-audit
+# per ADR-0001 (scitex-dev #139, Accepted 2026-06-07); `scitex.security`
+# lazily resolves to `scitex_audit.github` (see src/scitex/re_export.py
+# "security" mapping). The standalone `scitex-security` 0.2.0 is a
+# deprecated thin shim and is NOT pulled here.
 # Use: pip install scitex[security]
-security = []
+security = ["scitex-audit>=0.2.0"]
 
 # Session Module - Session management
 # Use: pip install scitex[session]
@@ -915,7 +922,7 @@ dev = [
     "scipy",
     "scitex-agent-container==0.21.9",
     "scitex-audio==0.2.13",
-    "scitex-audit==0.1.7",
+    "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
     "scitex-clew==0.2.15",
     # NOTE: scitex-hub (optional peer powering cloud/module/project; formerly

--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -151,7 +151,9 @@ notify = notification  # Backward compat alias
 git = _LazyModule("git", external="scitex_git")  # Git operations
 schema = _LazyModule("schema")  # Data schema utilities
 canvas = _LazyModule("canvas")  # Canvas utilities for figure composition
-security = _LazyModule("security", external="scitex_security")  # Security utilities
+security = _LazyModule(
+    "security", external="scitex_audit.github"
+)  # Security utilities — absorbed into scitex-audit per ADR-0001 (scitex-dev #139)
 benchmark = _LazyModule(
     "benchmark", external="scitex_benchmark"
 )  # Benchmarking utilities

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -269,7 +269,13 @@ EXTERNAL_REEXPORTS = {
     "introspect": "scitex_introspect",
     "msword": "scitex_msword",
     "os": "scitex_os",
-    "security": "scitex_security",
+    # `scitex.security` → `scitex_audit.github` per ADR-0001 (scitex-dev
+    # #139, 2026-06-07). scitex-security 0.1.4 was absorbed into
+    # scitex-audit 0.2.0; the 5 public symbols (check_github_alerts,
+    # save_alerts_to_file, get_latest_alerts_file, format_alerts_report,
+    # GitHubSecurityError) now live in scitex_audit.github. The standalone
+    # `scitex-security` 0.2.0 PyPI package is a deprecated thin shim only.
+    "security": "scitex_audit.github",
     "session": "scitex_session",  # @scitex.session decorator + INJECTED sentinel
     "tex": "scitex_tex",
 }


### PR DESCRIPTION
## Summary

W1 step for ADR-0001 (`ywatanabe1989/scitex-dev#139` — Accepted 2026-06-07). Repoints the umbrella's `scitex.security` lazy module to the new SSOT in `scitex_audit.github`, and swaps the `[security]` extra so it correctly installs `scitex-audit` (skill 03 §8 compliance).

**Depends on:** `ywatanabe1989/scitex-audit#23` (scitex-audit 0.2.0) — merge that + publish to PyPI first.

## Changes

| File | Change |
|---|---|
| `src/scitex/__init__.py` | `security = _LazyModule("security", external="scitex_security")` → `external="scitex_audit.github"`. |
| `src/scitex/re_export.py` | `"security": "scitex_security"` → `"security": "scitex_audit.github"` in the external-alias map. Paired with the lazy-module above so `import scitex.security` resolution is internally consistent. |
| `pyproject.toml` | `[audit] = ["scitex-audit==0.2.0"]` (was `0.1.7`); `[security] = ["scitex-audit>=0.2.0"]` (was `[]` — skill 03 §8 violation); drop `scitex-security==0.1.4` from main deps; bump `scitex-audit` pin in main deps + `[dev]` to `==0.2.0`. |
| `CHANGELOG.md` | `[Unreleased]` section with Changed / Removed / Migration. |

## Migration (user-facing)

```diff
- from scitex_security import check_github_alerts
+ from scitex_audit.github import check_github_alerts
+ # or just use the umbrella, which now resolves to the same SSOT:
+ from scitex.security import check_github_alerts
```

`scitex-security` console-script is replaced by `scitex-audit github` (the old name hard-errors with a redirect per CLI-deprecation skill 11 §5 in the deprecated 0.2.0 shim release).

`~/.scitex/security/` auto-symlinks to `~/.scitex/audit/github-alerts/` on first import of `scitex_audit` (one-shot, marker-gated, no manual step).

## Why a LazyModule + alias-map edit (no new bridge file)

Per skill 05 "Concrete pattern", the umbrella bridge is meant to be thin and grep-able. The umbrella already uses `_LazyModule` + the alias map (`scitex/re_export.py`) as its canonical bridge mechanism for every other absorbed/standalonized module (`stats`, `clew`, `errors`, etc.) — adding a `src/scitex/security/__init__.py` shim file would duplicate that pattern with no behavioural gain. The retarget keeps the umbrella's bridge surface uniform.

## Test plan

- [x] Static: `pyproject.toml` no longer references `scitex-security` as a hard dep; `re_export.py` + `__init__.py` both point to `scitex_audit.github`.
- [ ] CI green (requires scitex-audit 0.2.0 on PyPI; until then the `scitex-audit==0.2.0` pin won't resolve in CI's `.[all,dev]` install).
- [ ] Behavioural smoke: `from scitex.security import check_github_alerts` returns the same object as `from scitex_audit.github import check_github_alerts` post-merge.
- [ ] Merge order: scitex-audit#23 + PyPI publish → THEN this + scitex-security shim PR.

## Reference

- ADR-0001: <https://github.com/ywatanabe1989/scitex-dev/blob/develop/docs/adr/0001-absorb-scitex-security-into-scitex-audit.md>
- scitex-audit 0.2.0: <https://github.com/ywatanabe1989/scitex-audit/pull/23>
- scitex-security 0.2.0 shim: <https://github.com/ywatanabe1989/scitex-security/pull/12>
- Registry archive: <https://github.com/ywatanabe1989/scitex-dev/pull/140>