### PR TITLE
feat(deps): move click to [project.dependencies] (PS-213 console-script-deps-must-be-core)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,21 @@ dependencies = [
     "numpy",
     "pandas",
     "PyYAML",
+    # `click` is a HARD core dep — the `scitex-pkg` console-script
+    # (`scitex.cli.pkg:pkg`) does an UNGUARDED module-load `import click`
+    # at `src/scitex/cli/pkg.py:32`. Without it in core, bare
+    # `pip install scitex` followed by `scitex-pkg --help` raises
+    # ModuleNotFoundError. PS-213 console-script-deps-must-be-core
+    # (scitex-dev v0.17.10+) enforces this rule ecosystem-wide.
+    #
+    # The sibling `scitex` entry-point (`scitex.__main__:main`) uses the
+    # LAZY-EXTRA pattern — function-scope `import click` in
+    # `_check_cli_dependencies()` with a `pip install scitex[cli]` install
+    # hint — and would qualify for the PS-213i lazy-pass on its own, BUT
+    # `scitex-pkg` lives in the same package so the moment we ship a
+    # console-script that loads click unconditionally we have to make
+    # click a hard core dep.
+    "click>=8.0.0",
     "tqdm",
     "packaging",
     "natsort",  # Natural sorting - used by many modules
@@ -214,8 +229,15 @@ capture = [
 
 # CLI Module - Command line interface
 # Use: pip install scitex[cli]
+#
+# Note: `click` moved to [project.dependencies] (PS-213 dep-hygiene
+# wave): the `scitex-pkg` console-script does an unguarded module-load
+# `import click` so it must be core, not extras. The remaining entries
+# here are the LEGACY [cli] extras (requests/playwright/pyyaml/aiohttp/
+# beautifulsoup4/GitPython) that the higher-level CLI subcommands pull
+# in; keeping them as a coherent group preserves `pip install
+# scitex[cli]` ergonomics for the rest of the CLI feature set.
 cli = [
-    "click",
     "requests",
     "playwright",
     "pyyaml",


### PR DESCRIPTION
## Summary

Focused PR per the operator-approved ecosystem-wide dep-hygiene wave (after scitex-dev v0.17.10 landed the PS-213 audit rule). Lead's "split-the-work" call: **this PR does ONLY the click→core move; the full umbrella #326 extras refactor (40-line core → 8-line core, all leaves to extras) is HELD pending explicit operator confirmation**.

## What this PR changes

The umbrella's `scitex-pkg` console-script (`[project.scripts]` entry = `scitex.cli.pkg:pkg`) does an **unguarded module-load `import click`** at `src/scitex/cli/pkg.py:32`. Until now click lived in `[project.optional-dependencies].cli` only — so bare `pip install scitex` followed by `scitex-pkg --help` raises `ModuleNotFoundError`. The test matrix masked this because it installs `[all,dev]`.

- Move `click>=8.0.0` into `[project.dependencies]`.
- Remove the now-duplicate `"click"` entry from the `[cli]` extra. The rest of `[cli]` (requests / playwright / pyyaml / aiohttp / beautifulsoup4 / GitPython) remains the higher-level CLI feature set for users who want the full bundle via `pip install scitex[cli]`.

## What this PR does NOT change

Per lead's split-the-work decision:

- No 40→8 core reshape (that's #326).
- No leaves moving to extras (that's #326).
- No `bs4` move (that's #326).
- No leaf pin-floor changes.
- `scitex-dev>=0.16.0` pin is UNCHANGED (per lead's "no churn-for-harmonization" — we don't bump existing pin floors as part of this wave).

The full umbrella refactor branch is kept ready locally and will be pushed if/when the operator confirms #326.

## PS-213 boundary applied

Per the lead-endorsed rule:

- `scitex-pkg = scitex.cli.pkg:pkg` → module-load `import click` at line 32 → HARD core (this PR).
- `scitex = scitex.__main__:main` → uses the LAZY-EXTRA pattern (function-scope click import inside `_check_cli_dependencies()` + `pip install scitex[cli]` install hint) → would qualify for PS-213i LAZY-EXTRA-PATTERN-OK on its own. But once any console-script in the same package loads click unconditionally we must promote click to core.
- `scitex-mcp-server = scitex._mcp:main` → no click at module-load (uses fastmcp via `try_import_optional`).

## Pre-existing CI state on main

main's tests + quality have been **failing since 2026-06-09** (independent of this change; same pattern surfaced separately to operator as a quality follow-up). import-smoke + CLAssistant are green pre-merge. This PR's auto-merge gate is therefore NOT `mergeStateStatus = CLEAN` (which won't happen on a pre-red main); the gate is **"import-smoke green + only the pre-existing reds repeat"** and merge requires lead's explicit OK — no autonomous merge on a red main.

## Test plan

- [ ] CI: import-smoke (should pass — bare `pip install .` resolves click from core; assume sphinx/docs same as before).
- [ ] Quality (audit-all): expected to be RED (pre-existing).
- [ ] Tests: expected to be RED (pre-existing).
- [ ] Net: import-smoke = SUCCESS confirms the dep change is install-clean; surface CI to lead for merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)