### PR TITLE
fix(deps): bump 8 stale umbrella pins (PS-170 audit freshness — unblocks red main since Jun-9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,14 +83,14 @@ dependencies = [
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.8",
     # Delegated core modules (thin re-exports)
-    "scitex-dev==0.17.4",
-    "scitex-io==0.2.20",
-    "scitex-stats==0.2.23",
+    "scitex-dev==0.17.10",
+    "scitex-io==0.3.1",
+    "scitex-stats==0.2.24",
     "scitex-audio==0.2.13",
     "scitex-notification==0.2.8",
     "scitex-notebook==0.1.2",
     # Delegated modules from #51 standalonization
-    "scitex-db==0.1.11",
+    "scitex-db==0.1.12",
     "scitex-scholar==1.4.1",
     "scitex-parallel==0.1.8",
     "scitex-types==0.1.6",
@@ -109,7 +109,7 @@ dependencies = [
     "scitex-context==0.1.4",
     "scitex-cv==0.1.5",
     "scitex-introspect==0.1.7",
-    "scitex-msword==0.2.0",
+    "scitex-msword==0.3.2",
     "scitex-os==0.1.7",
     # scitex-security DROPPED here per ADR-0001 (scitex-dev #139) —
     # absorbed into scitex-audit. The [security] extra now installs
@@ -288,12 +288,12 @@ cv = [
 db = [
     "sqlalchemy",
     "psycopg2-binary",
-    "scitex-db==0.1.11",
+    "scitex-db==0.1.12",
 ]
 
 # Dataset Module - Dataset management
 # Use: pip install scitex[dataset]
-dataset = ["scitex-dataset==0.3.10"]
+dataset = ["scitex-dataset==0.4.0"]
 
 # Datetime Module - Date and time utilities
 # Use: pip install scitex[datetime]
@@ -403,7 +403,7 @@ git = [
 # IO Module - File I/O operations
 # Use: pip install scitex[io]
 io = [
-    "scitex-io==0.2.20",
+    "scitex-io==0.3.1",
     "h5py",
     "openpyxl",
     "xlrd",
@@ -694,7 +694,7 @@ social = [
 # Stats Module - Statistical analysis
 # Use: pip install scitex[stats]
 stats = [
-    "scitex-stats==0.2.23",
+    "scitex-stats==0.2.24",
     "scipy",
     "statsmodels",
     "matplotlib",
@@ -796,7 +796,7 @@ clew = ["scitex-clew==0.2.15"]
 # Writer Module - Academic paper writing
 # Use: pip install scitex[writer]
 writer = [
-    "scitex-writer==2.17.3",  # Core writer package (single source of truth)
+    "scitex-writer==2.17.5",  # Core writer package (single source of truth)
     "yq",
     "xlsx2csv",
     "csv2latex",
@@ -942,7 +942,7 @@ dev = [
     "scholarly",
     "scikit-learn",
     "scipy",
-    "scitex-agent-container==0.21.9",
+    "scitex-agent-container==0.21.11",
     "scitex-audio==0.2.13",
     "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
@@ -952,17 +952,17 @@ dev = [
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via
     # `pip install scitex[cloud]` when scitex-hub is available.
     "scitex-container==0.2.1",
-    "scitex-dataset==0.3.10",
-    "scitex-dev==0.17.4",
+    "scitex-dataset==0.4.0",
+    "scitex-dev==0.17.10",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
-    "scitex-io==0.2.20",
+    "scitex-io==0.3.1",
     "scitex-notification==0.2.8",
     "scitex-scholar==1.4.1",
     "scitex-ssh==1.0.1",
-    "scitex-stats==0.2.23",
+    "scitex-stats==0.2.24",
     "scitex-ui==0.5.1",
-    "scitex-writer==2.17.3",
+    "scitex-writer==2.17.5",
     "seaborn",
     "selenium",
     "setuptools",
@@ -1089,9 +1089,9 @@ all = [
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev==0.17.4"]
+linter = ["scitex-dev==0.17.10"]
 orochi = ["scitex-orochi==0.16.4"]
-agent-container = ["scitex-agent-container==0.21.9"]
+agent-container = ["scitex-agent-container==0.21.11"]
 
 [tool.hatch.version]
 path = "src/scitex/__version__.py"


### PR DESCRIPTION
## Root cause

Tests workflow has been red on `main` since Jun-9. **The failure is NOT in the test runner** — it is the pre-flight gating step `Audit umbrella pin freshness (PS-170)` in `.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml` (line 75):

```yaml
- name: Audit umbrella pin freshness (PS-170)
  run: |
    scitex-dev ecosystem audit-umbrella-pins . || exit 1
```

The auditor detects sub-package pins behind PyPI latest and exits 1, so the test runner never executes across all three matrix rows (py3.11 / 3.12 / 3.13).

Latest failed run (commit `1276698`, post-#328) reported 8 stale pins:

```
ERRO: ./pyproject.toml: PS-170: scitex-dev==0.17.4 but PyPI latest is 0.17.10. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-io==0.2.20 but PyPI latest is 0.3.1. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-stats==0.2.23 but PyPI latest is 0.2.24. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-db==0.1.11 but PyPI latest is 0.1.12. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-msword==0.2.0 but PyPI latest is 0.3.2. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-dataset==0.3.10 but PyPI latest is 0.4.0. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-writer==2.17.3 but PyPI latest is 2.17.5. Bump the umbrella pin.
ERRO: ./pyproject.toml: PS-170: scitex-agent-container==0.21.9 but PyPI latest is 0.21.11. Bump the umbrella pin.
```

## Fix

Canonical PS-170 bump — **no skip / no xfail / no -k exclusion**. Each pin updated to the exact PyPI-latest value reported by the auditor, across **18 occurrences** in `pyproject.toml`:

| Pin | Before | After |
|-----|--------|-------|
| scitex-dev | 0.17.4 | 0.17.10 |
| scitex-io | 0.2.20 | 0.3.1 |
| scitex-stats | 0.2.23 | 0.2.24 |
| scitex-db | 0.1.11 | 0.1.12 |
| scitex-msword | 0.2.0 | 0.3.2 |
| scitex-dataset | 0.3.10 | 0.4.0 |
| scitex-writer | 2.17.3 | 2.17.5 |
| scitex-agent-container | 0.21.9 | 0.21.11 |

Locations bumped (kept in lock-step so a future audit doesn't re-flag):

- `[project.dependencies]` (5 pins)
- `[project.optional-dependencies]`: `db`, `dataset`, `io`, `stats`, `writer` extras (5 pins)
- `[project.optional-dependencies].dev` block (6 pins)
- `[project.optional-dependencies]`: `linter`, `agent-container` extras (2 pins)

## Test plan

- [ ] CI `tests` matrix (py3.11 / 3.12 / 3.13): PS-170 step PASSES; the test runner then executes and surfaces any real failures, if any.
- [ ] CI `import-smoke` continues to pass.
- [ ] CI `docs` continues to pass.
- [ ] CI `scitex-quality-audit` PS-170 stops reporting stale pins.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
