### PR TITLE
feat(gen): FAIL-LOUD deprecation shim on the umbrella scitex.gen surface

### DIFF
--- a/src/scitex/__init__.py
+++ b/src/scitex/__init__.py
@@ -73,7 +73,17 @@ _register_external_lazy_modules()
 
 # Create lazy modules
 io = _LazyModule("io", external="scitex_io")
-gen = _LazyModule("gen", external="scitex_gen")
+# `gen` is NOT a peer re-export anymore. It is a FAIL-LOUD deprecation shim
+# (umbrella-only) — a real on-disk module at `src/scitex/gen.py` whose every
+# attribute access raises an AttributeError naming the focused package the
+# symbol moved to. NO fallback to the standalone `scitex_gen`. Importing the
+# module is cheap and side-effect-free; the error only fires on attribute
+# access (e.g. `scitex.gen.to_z`). Kept out of EXTERNAL_REEXPORTS (so the
+# eager lazy-registrar doesn't pre-register a `scitex_gen` proxy in
+# sys.modules), and the default path finder resolves this on-disk file before
+# the appended alias finder is ever consulted. See src/scitex/gen.py.
+from . import gen
+
 plt = _LazyModule("plt")
 ml = _LazyModule("ml", external="scitex_ml")
 genai = _LazyModule("genai", external="scitex_genai")

--- a/src/scitex/gen.py
+++ b/src/scitex/gen.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""scitex.gen — FAIL-LOUD deprecation shim (umbrella-only).
+
+``scitex.gen`` was the mngs-era kitchen-sink namespace. Its utilities have all
+moved into focused standalone packages (scitex-math, scitex-linalg,
+scitex-datetime, scitex-io, scitex-context, scitex-os, scitex-sh, scitex-str,
+scitex-introspect, scitex-stats). The umbrella no longer re-exports the
+standalone ``scitex_gen``: every attribute access on ``scitex.gen`` now raises
+a clear ``AttributeError`` naming the new home. Fail fast, fail loud, NO
+fallback — so stale ``scitex.gen.<x>`` callsites surface immediately at the
+exact line, instead of silently resolving to a soon-to-be-retired package.
+
+This shim is intentionally umbrella-only. The standalone ``scitex_gen`` package
+itself is untouched; only the ``scitex.gen`` umbrella surface fails loud.
+
+Mechanism: this is a real on-disk module (not a ``_LazyModule`` proxy to
+``scitex_gen``). Module-level ``__getattr__`` (PEP 562) looks the requested
+name up in ``_DEPRECATIONS`` and raises an ``AttributeError`` pointing at the
+umbrella target. Unmapped names get a generic fail-loud deprecation error.
+"""
+
+from __future__ import annotations
+
+# Nothing is publicly exported — every name fails loud via __getattr__.
+__all__: list = []
+
+
+# symbol -> umbrella target module shown in the deprecation message.
+# Keep this in sync with the migration audit; ONLY map names whose canonical
+# home is known. Unmapped names fall through to the generic fail-loud error.
+_DEPRECATIONS: dict = {
+    # → scitex.math
+    "to_even": "scitex.math",
+    "to_odd": "scitex.math",
+    # → scitex.linalg
+    "to_z": "scitex.linalg",
+    "to_nanz": "scitex.linalg",
+    "to_01": "scitex.linalg",
+    "to_nan01": "scitex.linalg",
+    "unbias": "scitex.linalg",
+    "clip_perc": "scitex.linalg",
+    "to_rank": "scitex.linalg",
+    "transpose": "scitex.linalg",
+    "symlog": "scitex.linalg",
+    "DimHandler": "scitex.linalg",
+    # → scitex.datetime
+    "TimeStamper": "scitex.datetime",
+    # → scitex.io
+    "xml2dict": "scitex.io",
+    "XmlDictConfig": "scitex.io",
+    "XmlListConfig": "scitex.io",
+    "mat2npy": "scitex.io",
+    "mat2dict": "scitex.io",
+    "mat2npa": "scitex.io",
+    "dir2npy": "scitex.io",
+    "keys2npa": "scitex.io",
+    "save_npa": "scitex.io",
+    # → scitex.context
+    "get_notebook_path": "scitex.context",
+    "get_notebook_name": "scitex.context",
+    "get_notebook_directory": "scitex.context",
+    "get_output_directory": "scitex.context",
+    "detect_environment": "scitex.context",
+    "is_notebook": "scitex.context",
+    # → scitex.path
+    "symlink": "scitex.path",
+    "src": "scitex.path",
+    "title2path": "scitex.path",
+    # → scitex.os
+    "check_host": "scitex.os",
+    "is_host": "scitex.os",
+    "verify_host": "scitex.os",
+    # → scitex.sh
+    "run_shellcommand": "scitex.sh",
+    "run_shellscript": "scitex.sh",
+    # → scitex.str
+    "title_case": "scitex.str",
+    # → scitex.introspect
+    "list_api": "scitex.introspect",
+    "list_packages": "scitex.introspect",
+    # → scitex.stats
+    "ci": "scitex.stats",
+}
+
+# The focused packages that absorbed scitex.gen — named in the generic error so
+# users know where to look even for an unmapped symbol.
+_TARGET_PACKAGES = "math/linalg/datetime/io/context/os/sh/str/introspect/stats"
+
+
+def __getattr__(name: str):
+    """PEP 562 hook: every attribute access on scitex.gen fails loud.
+
+    Mapped names point at the specific umbrella target; unmapped names get a
+    generic deprecation error. No fallback, no proxy to scitex_gen.
+    """
+    target = _DEPRECATIONS.get(name)
+    if target is not None:
+        raise AttributeError(
+            f"scitex.gen.{name} was deprecated and removed. "
+            f"Use {target}.{name} instead — scitex.gen is being retired; "
+            f"its utilities moved to focused packages."
+        )
+    raise AttributeError(
+        f"scitex.gen.{name}: scitex.gen is deprecated and being retired; "
+        f"its utilities moved to focused scitex packages "
+        f"({_TARGET_PACKAGES}). Import from the specific package instead."
+    )
+
+
+def __dir__() -> list:
+    """Surface the deprecated names for tab-completion/introspection so users
+    discover them (and then hit the fail-loud error explaining the move).
+    """
+    return sorted(_DEPRECATIONS)
+
+
+# EOF

--- a/src/scitex/re_export.py
+++ b/src/scitex/re_export.py
@@ -226,7 +226,13 @@ EXTERNAL_REEXPORTS = {
     "decorators": "scitex_decorators",
     "dsp": "scitex_dsp",
     "events": "scitex_events",
-    "gen": "scitex_gen",
+    # NOTE: `gen` is intentionally absent. `scitex.gen` is no longer a peer
+    # re-export of the standalone `scitex_gen`; it is a FAIL-LOUD deprecation
+    # shim shipped in-tree at `src/scitex/gen.py`. Leaving it out of this map
+    # prevents `register_external_lazy_modules()` from pre-registering a lazy
+    # `scitex_gen` proxy in `sys.modules["scitex.gen"]` (which would shadow the
+    # on-disk shim). The shim names the focused package each old symbol moved
+    # to and raises — no fallback to `scitex_gen`.
     "git": "scitex_git",
     "linalg": "scitex_linalg",
     "nn": "scitex_nn",

--- a/tests/scitex/test_gen_deprecation_shim.py
+++ b/tests/scitex/test_gen_deprecation_shim.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""FAIL-LOUD deprecation-shim tests for the umbrella ``scitex.gen`` surface.
+
+``scitex.gen`` is no longer a re-export of the standalone ``scitex_gen``. It is
+a deprecation shim: every attribute access raises ``AttributeError`` naming the
+focused package the symbol moved to (no fallback, no proxy). These tests pin
+that fail-loud contract with real imports — no mocks, no monkeypatch (STX-NM002).
+
+AAA structure, one assertion per test (``pytest.raises(..., match=...)`` folds
+the message check into the single assertion).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import scitex as stx
+
+
+def test_importing_gen_module_returns_the_umbrella_attribute():
+    """Importing the shim is side-effect-free and yields the same object."""
+    # Arrange
+    expected = stx.gen
+    # Act
+    mod = importlib.import_module("scitex.gen")
+    # Assert
+    assert mod is expected
+
+
+def test_gen_module_has_empty_public_surface():
+    """The shim exports nothing publicly — every name fails loud on access."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    public = mod.__all__
+    # Assert
+    assert public == []
+
+
+def test_to_z_raises_attribute_error_naming_linalg():
+    """``scitex.gen.to_z`` points migrants at scitex.linalg."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"scitex\.linalg")
+    # Assert
+    with expectation:
+        _ = mod.to_z
+
+
+def test_to_even_raises_attribute_error_naming_math():
+    """``scitex.gen.to_even`` points migrants at scitex.math."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"scitex\.math")
+    # Assert
+    with expectation:
+        _ = mod.to_even
+
+
+def test_timestamper_raises_attribute_error_naming_datetime():
+    """``scitex.gen.TimeStamper`` points migrants at scitex.datetime."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"scitex\.datetime")
+    # Assert
+    with expectation:
+        _ = mod.TimeStamper
+
+
+def test_dimhandler_raises_attribute_error_naming_linalg():
+    """``scitex.gen.DimHandler`` points migrants at scitex.linalg."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"scitex\.linalg")
+    # Assert
+    with expectation:
+        _ = mod.DimHandler
+
+
+def test_mapped_symbol_message_states_deprecated_and_removed():
+    """Mapped-symbol errors say the old name was deprecated AND removed."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"deprecated and removed")
+    # Assert
+    with expectation:
+        _ = mod.to_z
+
+
+def test_unmapped_name_raises_generic_fail_loud_error():
+    """An unmapped attribute hits the generic retirement error, not a guess."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError, match=r"deprecated and being retired")
+    # Assert
+    with expectation:
+        _ = mod.some_symbol_that_was_never_mapped
+
+
+def test_unmapped_name_message_lists_focused_packages():
+    """The generic error enumerates the focused packages to look in."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(
+        AttributeError,
+        match=r"math/linalg/datetime/io/context/os/sh/str/introspect/stats",
+    )
+    # Assert
+    with expectation:
+        _ = mod.some_symbol_that_was_never_mapped
+
+
+def test_gen_does_not_fall_back_to_standalone_scitex_gen():
+    """The shim must NOT proxy to scitex_gen — to_z exists there but must fail
+    on the umbrella surface (no fallback)."""
+    # Arrange
+    mod = stx.gen
+    # Act
+    expectation = pytest.raises(AttributeError)
+    # Assert
+    with expectation:
+        _ = mod.to_z
+
+
+# EOF

--- a/tests/scitex/test_subset_identity_peers.py
+++ b/tests/scitex/test_subset_identity_peers.py
@@ -31,7 +31,14 @@ PEERS: list = [  # list[tuple[str, str] | pytest.ParameterSet]
     ("scitex_stats", "scitex.stats"),
     ("scitex_dsp", "scitex.dsp"),
     ("scitex_config", "scitex.config"),
-    ("scitex_gen", "scitex.gen"),
+    # scitex.gen is INTENTIONALLY excluded from the peer-subset matrix. It is
+    # no longer a re-export of the standalone scitex_gen: the umbrella surface
+    # `scitex.gen` is now a FAIL-LOUD deprecation shim whose every attribute
+    # access raises an AttributeError naming the focused package the symbol
+    # moved to (scitex.math/linalg/datetime/io/context/os/sh/str/introspect/
+    # stats). Its public surface is intentionally empty (`__all__ == []`), so
+    # the peer ⊆ umbrella invariant does not — and must not — hold here. The
+    # shim's behavior is verified by tests/scitex/test_gen_deprecation_shim.py.
     ("scitex_pd", "scitex.pd"),
     ("scitex_dict", "scitex.dict"),
     ("scitex_str", "scitex.str"),


### PR DESCRIPTION
## What

Replace the umbrella's `scitex.gen` peer re-export of the standalone `scitex_gen` with a **FAIL-LOUD deprecation shim** (umbrella-only). `scitex.gen` was the mngs-era kitchen-sink namespace; its utilities have all moved into focused standalone packages. Every attribute access on `scitex.gen` now raises a clear `AttributeError` naming the focused package the symbol moved to. Fail fast, fail loud, **NO fallback/proxy** to `scitex_gen`.

```python
import scitex as stx
stx.gen.to_z
# AttributeError: scitex.gen.to_z was deprecated and removed. Use
# scitex.linalg.to_z instead — scitex.gen is being retired; its utilities
# moved to focused packages.
```

This is **umbrella-only**: the standalone `scitex_gen` package is untouched.

## Mechanism

- **`src/scitex/gen.py`** — new real on-disk module. `__all__ == []`; module-level `__getattr__` (PEP 562) looks the name up in a deprecation map and raises. Importing the module is cheap and side-effect-free; the error only fires on attribute access.
- **`src/scitex/re_export.py`** — drop `"gen"` from `EXTERNAL_REEXPORTS` so the eager lazy-registrar no longer pre-registers a `scitex_gen` proxy in `sys.modules["scitex.gen"]` (which would shadow the on-disk shim).
- **`src/scitex/__init__.py`** — bind `from . import gen` instead of `_LazyModule("gen", external="scitex_gen")`. The default path finder resolves the on-disk file before the appended alias finder is consulted, so the shim authoritatively wins (verified: `sys.modules['scitex.gen'].__file__` → `src/scitex/gen.py`).

## Deprecation map (symbol → umbrella target named in the message)

| target | symbols |
|---|---|
| `scitex.math` | to_even, to_odd |
| `scitex.linalg` | to_z, to_nanz, to_01, to_nan01, unbias, clip_perc, to_rank, transpose, symlog, DimHandler |
| `scitex.datetime` | TimeStamper |
| `scitex.io` | xml2dict, XmlDictConfig, XmlListConfig, mat2npy, mat2dict, mat2npa, dir2npy, keys2npa, save_npa |
| `scitex.context` | get_notebook_path, get_notebook_name, get_notebook_directory, get_output_directory, detect_environment, is_notebook |
| `scitex.path` | symlink, src, title2path |
| `scitex.os` | check_host, is_host, verify_host |
| `scitex.sh` | run_shellcommand, run_shellscript |
| `scitex.str` | title_case |
| `scitex.introspect` | list_api, list_packages |
| `scitex.stats` | ci |

Any **unmapped** name raises a generic fail-loud error enumerating the focused packages (`math/linalg/datetime/io/context/os/sh/str/introspect/stats`) — no guessed home.

## Tests

- **`tests/scitex/test_gen_deprecation_shim.py`** (new) — 10 AAA tests, **no mocks / no monkeypatch** (STX-NM002), real imports. Cover: `to_z`→linalg, `to_even`→math, `TimeStamper`→datetime, `DimHandler`→linalg, unmapped→generic error, empty public surface, "deprecated and removed" wording, and no fallback to `scitex_gen`.
- **`tests/scitex/test_subset_identity_peers.py`** — drop the `(scitex_gen, scitex.gen)` row. `gen` is intentionally a shim with an empty public surface, so the peer ⊆ umbrella invariant must not hold for it.
- The auto-generated `tests/integration/test_cross_package_imports.py` keeps its `scitex.gen._*` submodule rows; they now **skip cleanly** via its built-in `ModuleNotFoundError`-is-drift handling (the shim is a single-file module, not a package). Verified: 4 passed, 4 skipped for the `-k gen` selection.

### Local results
- `tests/scitex/test_gen_deprecation_shim.py`: **10 passed**
- `tests/scitex/`: **137 passed, 1 xfailed, 1 failed** — the single failure is `test_subset_identity_peers[scitex_security-scitex.security]`, a **pre-existing, unrelated** failure (`scitex.security` → `scitex_audit.github` migration; `scitex.security` does not import in this env). Independent of this change.