### PR TITLE
chore(deps): reconcile leaf pins to PyPI latest (umbrella 2.30.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.30.1"
+version = "2.30.2"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -79,11 +79,11 @@ dependencies = [
     # Config + env loading (scitex.helpers.load_scitex_env delegates here)
     "scitex-config==0.3.6",
     # Reproducibility Verification
-    "scitex-clew==0.2.15",
+    "scitex-clew==0.2.17",
     # App SDK — unified file storage for local + cloud
-    "scitex-app==0.2.8",
+    "scitex-app==0.2.10",
     # Delegated core modules (thin re-exports)
-    "scitex-dev==0.17.10",
+    "scitex-dev==0.18.0",
     "scitex-io==0.3.1",
     "scitex-stats==0.2.24",
     "scitex-audio==0.2.13",
@@ -96,7 +96,7 @@ dependencies = [
     "scitex-types==0.1.6",
     "scitex-path==0.1.7",
     "scitex-repro==0.1.6",
-    "scitex-compat==0.1.8",
+    "scitex-compat==0.1.9",
     "scitex-etc==0.2.0",  # media shipped here; scitex.media re-exports scitex_etc.media
     "scitex-genai==0.1.0",
     "scitex-gists==0.1.7",
@@ -167,7 +167,7 @@ scitex = "scitex"
 # App Module - Unified file storage SDK (local + cloud)
 # Use: pip install scitex[app]
 app = [
-    "scitex-app==0.2.8",
+    "scitex-app==0.2.10",
 ]
 
 # ML Module — classical / deep machine-learning utilities
@@ -264,7 +264,7 @@ hub = [
 
 # Compat Module - Compatibility utilities
 # Use: pip install scitex[compat]
-compat = ["scitex-compat==0.1.8"]
+compat = ["scitex-compat==0.1.9"]
 
 # Config Module - Configuration management
 # Use: pip install scitex[config]
@@ -674,7 +674,7 @@ security = ["scitex-audit>=0.2.0"]
 # Session Module - Session management
 # Use: pip install scitex[session]
 session = [
-    "scitex-session==0.2.1",
+    "scitex-session==0.2.3",
     "matplotlib",
     "PyYAML",
 ]
@@ -791,7 +791,7 @@ web = [
 # Clew Module - Hash-based verification for reproducible science (Ariadne's thread)
 # Use: pip install scitex[clew]
 # Note: No extra dependencies - uses only stdlib (sqlite3, hashlib)
-clew = ["scitex-clew==0.2.15"]
+clew = ["scitex-clew==0.2.17"]
 
 # Writer Module - Academic paper writing
 # Use: pip install scitex[writer]
@@ -946,14 +946,14 @@ dev = [
     "scitex-audio==0.2.13",
     "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
-    "scitex-clew==0.2.15",
+    "scitex-clew==0.2.17",
     # NOTE: scitex-hub (optional peer powering cloud/module/project; formerly
     # scitex-cloud) is intentionally NOT in [dev] — it is unreleased, so listing
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via
     # `pip install scitex[cloud]` when scitex-hub is available.
     "scitex-container==0.2.1",
     "scitex-dataset==0.4.0",
-    "scitex-dev==0.17.10",
+    "scitex-dev==0.18.0",
     "scitex-etc==0.2.0",
     "scitex-genai==0.1.0",
     "scitex-io==0.3.1",
@@ -1089,7 +1089,7 @@ all = [
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev==0.17.10"]
+linter = ["scitex-dev==0.18.0"]
 orochi = ["scitex-orochi==0.16.4"]
 agent-container = ["scitex-agent-container==0.21.11"]
 


### PR DESCRIPTION
## Summary

Reconcile the umbrella's hard-pinned leaf versions to the **latest on PyPI**, keeping the `==` form (reproducible). Operator directive: *"update the umbrella to keep up with the leaf versions."*

## Leaf pin changes (old → new)

| Leaf | Old | New | Bump | Occurrences updated |
|------|-----|-----|------|---------------------|
| `scitex-app` | 0.2.8 | **0.2.10** | patch | 2 |
| `scitex-clew` | 0.2.15 | **0.2.17** | patch | 3 (verify-gate, just released) |
| `scitex-compat` | 0.1.8 | **0.1.9** | patch | 2 |
| `scitex-dev` | 0.17.10 | **0.18.0** | minor | 3 |
| `scitex-session` | 0.2.1 | **0.2.3** | patch | 1 |

All other **35** single-word leaf `==` pins already matched PyPI latest. `scitex-agent-container==0.21.11` (multiword name) also already latest. The `scitex-hub>=0.19.0` and `scitex-audit>=0.2.0` specifiers are intentional `>=` floors (ranges, not hard-pins) and are left unchanged; `scitex-hub` is unreleased.

After this change, every `==` leaf pin in `pyproject.toml` equals its PyPI `LATEST:` and is internally consistent across all extras / dependency lists (verified programmatically against the full 40-leaf latest map).

## Umbrella version

`2.30.1 → 2.30.2` (**patch**). No leaf had a *major* bump — `scitex-dev` 0.17→0.18 is minor — so a patch bump is appropriate for a pin reconciliation.

## Green-gate (run locally from the worktree, before push)

- **`scitex-dev ecosystem audit-all scitex --path .`**: **delta-neutral**. The fresh checkout reports 113 errors *both before and after* this change (proven by reverting the pin diff and re-auditing). Every one is pre-existing baseline (PS-139 umbrella `scitex[extra]` self-references, PS-202/203 test-layout, PS-PATH-001 in `examples/_legacy/`), none touched by version numbers. This PR introduces **0 new audit errors**.
- **`pytest tests/scitex/ -q`**: **154 passed, 1 skipped, 1 xfailed, 1 failed**. The single failure (`scitex.security` not reachable via umbrella facade) is **pre-existing and unrelated** — it reproduces identically on the pristine tree, and `scitex-security` is not a pin this PR touches.

No leaf was held back: all five bumps coexist cleanly with the umbrella (no import/test/dep-conflict regression).