### PR TITLE
chore(deps): cut 2.30.4 — sweep umbrella pins to PyPI latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.4] - 2026-06-29
+
 ### Changed
+- **Umbrella `==` pin bumps to PyPI latest (PS-170 freshness sweep).**
+  figrecipe 0.29.5→0.29.9 (NeuroVista grant figure fixes: caption justify,
+  title-aware 10pt-bold-Arial panel labels, imshow aspect honoring,
+  numpy-scalar recipe-save crash), scitex-writer 2.22.0→2.23.0,
+  scitex-clew 0.2.17→0.2.18. Lets downstream research projects pin
+  `figrecipe==0.29.9` consistently alongside `scitex==2.30.4`.
 - **`_LazyModule` error messages now name the canonical attribute home when
   one exists.** When `scitex.<short>.<attr>` lookup fails because `<short>`
   is not installed (extras gate) or because `<short>` is installed but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.30.3"
+version = "2.30.4"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -79,7 +79,7 @@ dependencies = [
     # Config + env loading (scitex.helpers.load_scitex_env delegates here)
     "scitex-config==0.3.6",
     # Reproducibility Verification
-    "scitex-clew==0.2.17",
+    "scitex-clew==0.2.18",
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.11",
     # Delegated core modules (thin re-exports)
@@ -117,7 +117,7 @@ dependencies = [
     # scitex-audit; scitex-python's main deps no longer pull the
     # deprecated 0.1.4 standalone.
     "scitex-tex==0.1.7",
-    "figrecipe==0.29.5",
+    "figrecipe==0.29.9",
     "scitex-ui==0.6.0",
 ]
 
@@ -560,7 +560,7 @@ plt = [
     "pyyaml",
     "joblib",
     "ruamel.yaml",
-    "figrecipe==0.29.5",
+    "figrecipe==0.29.9",
 ]
 
 # Project Module - Project management (OPTIONAL peer: scitex-hub.project)
@@ -793,12 +793,12 @@ web = [
 # Clew Module - Hash-based verification for reproducible science (Ariadne's thread)
 # Use: pip install scitex[clew]
 # Note: No extra dependencies - uses only stdlib (sqlite3, hashlib)
-clew = ["scitex-clew==0.2.17"]
+clew = ["scitex-clew==0.2.18"]
 
 # Writer Module - Academic paper writing
 # Use: pip install scitex[writer]
 writer = [
-    "scitex-writer==2.22.0",  # Core writer package (single source of truth)
+    "scitex-writer==2.23.0",  # Core writer package (single source of truth)
     "yq",
     "xlsx2csv",
     "csv2latex",
@@ -865,7 +865,7 @@ dev = [
     "crossref-local==0.7.6",
     "csv2latex",
     "feedparser",
-    "figrecipe==0.29.5",
+    "figrecipe==0.29.9",
     "flask>=2.0.0",
     "geom_median",
     "GitPython",
@@ -948,7 +948,7 @@ dev = [
     "scitex-audio==0.3.0",
     "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
-    "scitex-clew==0.2.17",
+    "scitex-clew==0.2.18",
     # NOTE: scitex-hub (optional peer powering cloud/module/project; formerly
     # scitex-cloud) is intentionally NOT in [dev] — it is unreleased, so listing
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via
@@ -964,7 +964,7 @@ dev = [
     "scitex-ssh==1.0.1",
     "scitex-stats==0.2.24",
     "scitex-ui==0.6.0",
-    "scitex-writer==2.22.0",
+    "scitex-writer==2.23.0",
     "seaborn",
     "selenium",
     "setuptools",


### PR DESCRIPTION
## Summary
Operator-directed release cut (\`はいどんどん公開してください\`): bump scitex 2.30.3 → **2.30.4** and sweep all drifted umbrella `==` pins to PyPI latest (PS-170 freshness).

Three pins had drifted past the 2.30.3 baseline (the 2.30.3 cut already brought every other leaf current):
- **figrecipe** 0.29.5 → **0.29.9** (NeuroVista grant figure fixes: caption justify, title-aware 10pt-bold-Arial panel labels, imshow aspect honoring, numpy-scalar recipe-save crash)
- **scitex-writer** 2.22.0 → **2.23.0**
- **scitex-clew** 0.2.17 → **0.2.18**

Why figrecipe matters: lets a downstream research project (NeuroVista) pin `figrecipe==0.29.9` consistently alongside `scitex==2.30.4` — the umbrella's strict `==` pin previously forced figrecipe down to 0.29.5, conflicting with the newer leaf the project needs.

## Validation
- `scitex-dev ecosystem audit-umbrella-pins . --strict` → **SUCC: all umbrella pins fresh** (release-pipeline gate green).
- Bumped in core deps + the relevant extras + `[dev]`.

## Test plan
- [ ] CI green (pytest-matrix 3.11–3.13, import-smoke, audit, sphinx)
- [ ] `pip install scitex[all]==2.30.4` resolves with figrecipe 0.29.9
- [ ] On merge: tag \`v2.30.4\` → self-hosted publish pipeline → PyPI