### PR TITLE
test(io): make scitex.io.bundle attribute assertions xdist-deterministic

### DIFF
--- a/tests/integration/io/test___init__.py
+++ b/tests/integration/io/test___init__.py
@@ -12,6 +12,16 @@ import pytest
 
 import scitex.io as sio
 
+# `scitex.io.bundle` is a submodule: per Python import semantics it only
+# becomes an attribute of `scitex.io` once it has been imported. Import it
+# explicitly here so the attribute-access assertions below are deterministic
+# under pytest-xdist — relying on a sibling test to have imported it first is
+# worker-distribution-dependent and flakes when this file lands on a worker
+# that hasn't (the v2.30.4 release-SIF flake). `import scitex.io.bundle` is the
+# supported access path; the standalone `scitex_io` does not eagerly bind it
+# either.
+import scitex.io.bundle  # noqa: F401,E402
+
 
 @pytest.mark.parametrize(
     "name",


### PR DESCRIPTION
## Summary
Fixes the flaky test that blocked the **v2.30.4 release SIF** (`test_bundle_submodule_is_a_package`).

Root cause: the test does `import scitex.io as sio` then asserts `sio.bundle` — attribute access on a submodule **without importing it**. Per Python semantics a submodule only becomes an attribute of its parent once imported, so this only passes when *another* test in the session imported `scitex.io.bundle` first. Under pytest-xdist (`-n --dist load`) that's worker-distribution-dependent: v2.30.3's release run got a worker that had it; v2.30.4's didn't.

**Not a regression and not the 2.30.4 pin bump** — reproduces back to scitex 2.30.0. The product is fine: `import scitex.io.bundle` is the supported access path and works (verified).

Fix: `import scitex.io.bundle` at module top so the attribute assertions are deterministic on every worker.

## Test plan
- [ ] CI green
- [ ] v2.30.4 release SIF re-run passes (re-tag after merge)