### PR TITLE
release: scitex 2.30.5 (umbrella pin sweep — writer incident gate + dev compliance linter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.5] - 2026-06-30
+
+### Changed
+- **Umbrella `==` pin bumps to PyPI latest (PS-170 freshness sweep).**
+  scitex-writer 2.23.0→2.24.1 (post-compile fail-loud verification gate +
+  clew verify gate + markers/colophon — the fix for the figure-less-PDF
+  incident, so `scitex[writer]` consumers get the gate), scitex-dev
+  0.20.1→0.21.0 (the unified compliance-linter trio: figure-lint v1 +
+  raw-import research-ERROR + `--new-only` baseline gate), scitex-clew
+  0.2.18→0.2.22.
+
 ## [2.30.4] - 2026-06-29
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex"
-version = "2.30.4"
+version = "2.30.5"
 description = "A comprehensive Python library for scientific computing and data analysis"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -79,11 +79,11 @@ dependencies = [
     # Config + env loading (scitex.helpers.load_scitex_env delegates here)
     "scitex-config==0.3.6",
     # Reproducibility Verification
-    "scitex-clew==0.2.18",
+    "scitex-clew==0.2.22",
     # App SDK — unified file storage for local + cloud
     "scitex-app==0.2.11",
     # Delegated core modules (thin re-exports)
-    "scitex-dev==0.20.1",
+    "scitex-dev==0.21.0",
     "scitex-io==0.3.3",
     "scitex-stats==0.2.24",
     "scitex-audio==0.3.0",
@@ -793,12 +793,12 @@ web = [
 # Clew Module - Hash-based verification for reproducible science (Ariadne's thread)
 # Use: pip install scitex[clew]
 # Note: No extra dependencies - uses only stdlib (sqlite3, hashlib)
-clew = ["scitex-clew==0.2.18"]
+clew = ["scitex-clew==0.2.22"]
 
 # Writer Module - Academic paper writing
 # Use: pip install scitex[writer]
 writer = [
-    "scitex-writer==2.23.0",  # Core writer package (single source of truth)
+    "scitex-writer==2.24.1",  # Core writer package (single source of truth)
     "yq",
     "xlsx2csv",
     "csv2latex",
@@ -948,14 +948,14 @@ dev = [
     "scitex-audio==0.3.0",
     "scitex-audit==0.2.0",
     "scitex-browser==0.1.15",
-    "scitex-clew==0.2.18",
+    "scitex-clew==0.2.22",
     # NOTE: scitex-hub (optional peer powering cloud/module/project; formerly
     # scitex-cloud) is intentionally NOT in [dev] — it is unreleased, so listing
     # it here would break CI's `.[all,dev]` resolve. Install explicitly via
     # `pip install scitex[cloud]` when scitex-hub is available.
     "scitex-container==0.2.1",
     "scitex-dataset==0.5.0",
-    "scitex-dev==0.20.1",
+    "scitex-dev==0.21.0",
     "scitex-etc==0.2.1",
     "scitex-genai==0.1.1",
     "scitex-io==0.3.3",
@@ -964,7 +964,7 @@ dev = [
     "scitex-ssh==1.0.1",
     "scitex-stats==0.2.24",
     "scitex-ui==0.6.0",
-    "scitex-writer==2.23.0",
+    "scitex-writer==2.24.1",
     "seaborn",
     "selenium",
     "setuptools",
@@ -1091,7 +1091,7 @@ all = [
 # ============================================
 # Tool Configurations
 # ============================================
-linter = ["scitex-dev==0.20.1"]
+linter = ["scitex-dev==0.21.0"]
 orochi = ["scitex-orochi==0.17.0"]
 agent-container = ["scitex-agent-container==0.21.11"]
 


### PR DESCRIPTION
## Summary
Autonomous release cut (operator standing §14 authorization). scitex 2.30.4 → **2.30.5**, sweeping drifted umbrella `==` pins to PyPI latest (PS-170):
- **scitex-writer** 2.23.0 → **2.24.1** — the post-compile fail-loud verification gate + clew verify gate + markers/colophon (the fix for the figure-less-PDF incident), so `scitex[writer]` consumers get the gate.
- **scitex-dev** 0.20.1 → **0.21.0** — the unified compliance-linter trio (figure-lint v1 + raw-import research-ERROR + `--new-only` baseline gate).
- **scitex-clew** 0.2.18 → **0.2.22**.

`scitex-dev ecosystem audit-umbrella-pins . --strict` → **all umbrella pins fresh**.

## Test plan
- [ ] CI green (pytest-matrix 3.11–3.13 + import-smoke + sphinx + docs)
- [ ] On merge: tag `v2.30.5` → self-hosted publish pipeline → PyPI (watch the release SIF test stage for version-coupled-dep landmines)