### PR TITLE
fix(mcp): aggregator mount policy (skip orochi+types) + cold-start CI guard

### DIFF
--- a/src/scitex/_mcp/__init__.py
+++ b/src/scitex/_mcp/__init__.py
@@ -80,6 +80,14 @@ _MCP_ATTR_CANDIDATES = ("mcp", "server", "app")
 # Categories the umbrella does NOT mount.
 _SKIP_CATEGORIES = frozenset({"umbrella", "template"})
 
+# Packages the umbrella never mounts even when scitex-dev is too old to
+# carry the ``is_mcp_mountable`` SSoT. ``scitex-orochi`` is the
+# single-instance agent-communication ORCHESTRATOR — its ``mcp_server``
+# guards refuse to run alongside the Telegram bot and it is not a
+# per-agent tool provider, so mounting it is both wrong and a cold-start
+# hazard. Kept in sync with scitex-dev ``_core._MCP_UNMOUNTABLE``.
+_LOCAL_UNMOUNTABLE = frozenset({"scitex-orochi"})
+
 # Namespace overrides — registry's ``umbrella_subcommand`` may differ from
 # the prefix consumers already know. Apply these renames so existing tool
 # names (``crossref_search``, not ``crossref-local_search``) survive.
@@ -145,6 +153,34 @@ def _resolve_peer_mcp(import_name: str):
     return None
 
 
+def _mount_skip(pip_name: str, info: dict) -> bool:
+    """Return True iff ``pip_name`` must NOT be auto-mounted.
+
+    Prefers scitex-dev's ``is_mcp_mountable`` SSoT (which also skips the
+    orchestrator ``scitex-orochi`` and any entry with ``mcp_mountable:
+    False``). Falls back to the local archived/category/field checks when
+    an older scitex-dev without that helper is installed, so the umbrella
+    keeps working across the coordinated two-repo rollout.
+    """
+    try:
+        from scitex_dev._ecosystem._core import is_mcp_mountable
+    except ImportError:
+        is_mcp_mountable = None
+
+    if is_mcp_mountable is not None:
+        return not is_mcp_mountable(pip_name)
+
+    # Fallback (older scitex-dev): replicate the SSoT's checks inline plus
+    # the local unmountable guard so the orchestrator is skipped even when
+    # the installed scitex-dev predates the ``is_mcp_mountable`` helper.
+    return bool(
+        pip_name in _LOCAL_UNMOUNTABLE
+        or info.get("archived")
+        or info.get("category") in _SKIP_CATEGORIES
+        or info.get("mcp_mountable") is False
+    )
+
+
 def _iter_registry() -> Iterable[tuple[str, str, str]]:
     """Yield ``(pip_name, import_name, namespace)`` for every mountable peer."""
     try:
@@ -154,9 +190,7 @@ def _iter_registry() -> Iterable[tuple[str, str, str]]:
         return
 
     for pip_name, info in ECOSYSTEM.items():
-        if info.get("archived"):
-            continue
-        if info.get("category") in _SKIP_CATEGORIES:
+        if _mount_skip(pip_name, info):
             continue
         import_name = info.get("import_name")
         if not import_name:

--- a/src/scitex/_mcp/__init__.py
+++ b/src/scitex/_mcp/__init__.py
@@ -81,12 +81,16 @@ _MCP_ATTR_CANDIDATES = ("mcp", "server", "app")
 _SKIP_CATEGORIES = frozenset({"umbrella", "template"})
 
 # Packages the umbrella never mounts even when scitex-dev is too old to
-# carry the ``is_mcp_mountable`` SSoT. ``scitex-orochi`` is the
-# single-instance agent-communication ORCHESTRATOR — its ``mcp_server``
-# guards refuse to run alongside the Telegram bot and it is not a
-# per-agent tool provider, so mounting it is both wrong and a cold-start
-# hazard. Kept in sync with scitex-dev ``_core._MCP_UNMOUNTABLE``.
-_LOCAL_UNMOUNTABLE = frozenset({"scitex-orochi"})
+# carry the ``is_mcp_mountable`` SSoT. Kept in sync with scitex-dev
+# ``_core._MCP_UNMOUNTABLE``.
+#   - ``scitex-orochi``: the single-instance agent-communication
+#     ORCHESTRATOR — its ``mcp_server`` guards refuse to run alongside the
+#     Telegram bot and it is not a per-agent tool provider, so mounting it
+#     is both wrong and a cold-start hazard.
+#   - ``scitex-types``: ships NO ``_mcp_server`` (zero tools) yet importing
+#     it pulls the heavy scientific stack (numpy/torch/…). Probing it for a
+#     non-existent FastMCP is pure cold-start waste.
+_LOCAL_UNMOUNTABLE = frozenset({"scitex-orochi", "scitex-types"})
 
 # Namespace overrides — registry's ``umbrella_subcommand`` may differ from
 # the prefix consumers already know. Apply these renames so existing tool

--- a/tests/scitex/_mcp/test___init__.py
+++ b/tests/scitex/_mcp/test___init__.py
@@ -126,6 +126,46 @@ def test_crossref_namespace_alias_applied():
     assert "crossref-local" not in prefixes
 
 
+def test_iter_registry_excludes_orochi_orchestrator():
+    # Arrange
+    from scitex._mcp import _iter_registry
+
+    # Act
+    pip_names = {row[0] for row in _iter_registry()}
+    # Assert
+    assert "scitex-orochi" not in pip_names
+
+
+def test_iter_registry_includes_core_library_peer():
+    # Arrange
+    from scitex._mcp import _iter_registry
+
+    # Act
+    pip_names = {row[0] for row in _iter_registry()}
+    # Assert
+    assert "scitex-io" in pip_names
+
+
+def test_mount_skip_true_for_orochi_orchestrator():
+    # Arrange
+    from scitex._mcp import _mount_skip
+
+    # Act
+    skipped = _mount_skip("scitex-orochi", {"import_name": "scitex_orochi"})
+    # Assert
+    assert skipped is True
+
+
+def test_mount_skip_false_for_core_library_peer():
+    # Arrange
+    from scitex._mcp import _mount_skip
+
+    # Act
+    skipped = _mount_skip("scitex-io", {"import_name": "scitex_io"})
+    # Assert
+    assert skipped is False
+
+
 def test_peer_extras_registration_folds_in_brand_renamed_tools():
     # Arrange
     from fastmcp import FastMCP

--- a/tests/scitex/_mcp/test___init__.py
+++ b/tests/scitex/_mcp/test___init__.py
@@ -136,6 +136,16 @@ def test_iter_registry_excludes_orochi_orchestrator():
     assert "scitex-orochi" not in pip_names
 
 
+def test_iter_registry_excludes_types_zero_tool_peer():
+    # Arrange
+    from scitex._mcp import _iter_registry
+
+    # Act
+    pip_names = {row[0] for row in _iter_registry()}
+    # Assert
+    assert "scitex-types" not in pip_names
+
+
 def test_iter_registry_includes_core_library_peer():
     # Arrange
     from scitex._mcp import _iter_registry
@@ -144,6 +154,16 @@ def test_iter_registry_includes_core_library_peer():
     pip_names = {row[0] for row in _iter_registry()}
     # Assert
     assert "scitex-io" in pip_names
+
+
+def test_mount_skip_true_for_types_zero_tool_peer():
+    # Arrange
+    from scitex._mcp import _mount_skip
+
+    # Act
+    skipped = _mount_skip("scitex-types", {"import_name": "scitex_types"})
+    # Assert
+    assert skipped is True
 
 
 def test_mount_skip_true_for_orochi_orchestrator():


### PR DESCRIPTION
## Incident: umbrella MCP aggregator cold-start too slow (agents ran with tools dark)

The **scitex-python** slice of the coordinated fix + the CI guardrail.

### Changes
- `_iter_registry` delegates the skip decision to a new `_mount_skip()` that prefers scitex-dev's `is_mcp_mountable()` SSoT and falls back to local `archived`/`category`/`mcp_mountable` checks plus a self-contained `_LOCAL_UNMOUNTABLE = {scitex-orochi, scitex-types}` guard (so the orchestrator + the zero-tool peer are skipped even against an older installed scitex-dev). Rides on top of the #347/#348 bounded per-peer mount — skipped peers are removed **before** resolution, so no bounded daemon thread even spawns for them.
- **CI cold-start guardrail** (`test_coldstart_guard.py`): a deterministic test asserting `import scitex._mcp` does NOT pull `matplotlib.pyplot` (the SIF 50-70s font-scan trigger), plus a soft time ceiling (`SCITEX_MCP_COLDSTART_MAX_S`, default 30s).

### Profile (core scitex 2.30.7, cold MPLCONFIGDIR)
Baseline real `import scitex._mcp` = **24.99s** with `matplotlib.pyplot`+`font_manager` loaded at mount. After the coordinated peer fixes = **13.46s** with only `matplotlib` core loaded (no pyplot/font_manager) — same 11 peers / 387 tools. The root cause was **scitex-session** dragging matplotlib.pyplot onto the mount path (fixed in its own PR).

### Note on the "no timeout" scare (retracted)
An early read suggested the aggregator had no per-peer timeout; that was from a **stale local develop (19 commits behind origin/develop)**. #347/#348 (`_resolve_one_peer_bounded`, `SCITEX_MCP_PEER_TIMEOUT` default 8s) ARE present; this branch was rebased onto origin/develop so the skip logic sits on top of the bounded mount.

### Tests
23 passed, 1 skipped (CI guard + entrypoint + orochi/types skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
