### PR TITLE
fix(mcp): sync _LOCAL_UNMOUNTABLE fallback to skip scitex-str (cold-start)

### DIFF
--- a/src/scitex/_mcp/__init__.py
+++ b/src/scitex/_mcp/__init__.py
@@ -90,7 +90,14 @@ _SKIP_CATEGORIES = frozenset({"umbrella", "template"})
 #   - ``scitex-types``: ships NO ``_mcp_server`` (zero tools) yet importing
 #     it pulls the heavy scientific stack (numpy/torch/…). Probing it for a
 #     non-existent FastMCP is pure cold-start waste.
-_LOCAL_UNMOUNTABLE = frozenset({"scitex-orochi", "scitex-types"})
+#   - ``scitex-str``: likewise ships NO ``_mcp`` server (zero tools — pure
+#     text-utility library) yet importing ``scitex_str`` eagerly pulls
+#     pandas + numpy via its ``_search`` / ``_plot`` submodules. Same
+#     cold-start waste as ``scitex-types`` (sac real-SIF re-verify of
+#     umbrella 2.30.8).
+_LOCAL_UNMOUNTABLE = frozenset(
+    {"scitex-orochi", "scitex-types", "scitex-str"}
+)
 
 # Namespace overrides — registry's ``umbrella_subcommand`` may differ from
 # the prefix consumers already know. Apply these renames so existing tool

--- a/tests/scitex/_mcp/test___init__.py
+++ b/tests/scitex/_mcp/test___init__.py
@@ -176,6 +176,43 @@ def test_mount_skip_true_for_orochi_orchestrator():
     assert skipped is True
 
 
+def test_local_unmountable_fallback_lists_zero_tool_peers():
+    # Arrange — the fallback set used when the installed scitex-dev predates
+    # the ``is_mcp_mountable`` SSoT. Must stay in sync with scitex-dev
+    # ``_core._MCP_UNMOUNTABLE`` so str/types/orochi are skipped either way.
+    from scitex._mcp import _LOCAL_UNMOUNTABLE
+
+    expected = {"scitex-orochi", "scitex-types", "scitex-str"}
+    # Act
+    covered = expected <= _LOCAL_UNMOUNTABLE
+    # Assert
+    assert covered is True
+
+
+def test_mount_skip_true_for_str_via_local_fallback():
+    # Arrange — force the fallback path by masking scitex-dev's helper so the
+    # test is independent of the installed scitex-dev version.
+    import builtins
+
+    from scitex import _mcp
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name == "scitex_dev._ecosystem._core":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = _blocked
+    try:
+        # Act
+        skipped = _mcp._mount_skip("scitex-str", {"import_name": "scitex_str"})
+    finally:
+        builtins.__import__ = real_import
+    # Assert
+    assert skipped is True
+
+
 def test_mount_skip_false_for_core_library_peer():
     # Arrange
     from scitex._mcp import _mount_skip


### PR DESCRIPTION
## Summary
The umbrella aggregator's `_mount_skip` prefers scitex-dev's `is_mcp_mountable` SSoT and falls back to the local `_LOCAL_UNMOUNTABLE` set when an older scitex-dev (without that helper) is installed. `scitex-str` ships **no** `_mcp` server (zero tools) yet importing `scitex_str` eagerly pulls **pandas + numpy** via its `_search` / `_plot` submodules (~1.4s cold) — pure cold-start waste, exactly like `scitex-types`.

Add `scitex-str` to the fallback set so the skip holds across the coordinated two-repo rollout even before the scitex-dev SSoT bump (ywatanabe1989/scitex-dev#309) is installed. Once that lands, `is_mcp_mountable` drives the skip; this keeps the fallback correct meanwhile.

Diagnosed in sac's real-SIF re-verify of umbrella 2.30.8 — `scitex-str` + `scitex-resource` were the residual 16s (8s each) after the font-scan fix. Pairs with scitex-resource#25 (lazy pandas/yaml).

## Test
`tests/scitex/_mcp/test___init__.py`: asserts `_LOCAL_UNMOUNTABLE` covers orochi/types/str, and `_mount_skip('scitex-str', ...)` returns True via the forced-fallback path (masks the scitex-dev helper so the test is independent of the installed scitex-dev version). 4 passed locally.

Feeds umbrella 2.30.9.