### PR TITLE
chore(ci): migrate to scitex-ai/.github reusable workflows (pilot follow-up)

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -1,9 +1,10 @@
 name: auto-merge-to-develop
-# Merge green PRs that TARGET develop, the moment their checks complete.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
 # GitHub reads check_suite-triggered workflows from the DEFAULT branch (main),
-# so this file lives on main but acts ONLY on PRs whose base is develop.
-# codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
-# is blocked by branch policy the PR simply stays open.
+# so this file must stay on main, acting only on PRs whose base is develop
+# (unchanged from before). Job body verified byte-identical to the reusable
+# workflow's `automerge` job before conversion — clean mechanical match.
 on:
   check_suite:
     types: [completed]
@@ -14,36 +15,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What

Pilot org-level reusable-workflow migration (operator-approved 2026-07-10 incident remediation), following the pattern merged in `scitex-ai/scitex-stats#69`. Replaces job bodies with thin `workflow_call` stubs into `scitex-ai/.github` reusable workflows where — and only where — the local job is a clean, verified mechanical match. Triggers/permissions preserved byte-identical on the one file touched.

## Converted

- **`auto-merge-to-develop.yaml`** → `uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main`. Verified the job body (the `automerge` step script) was byte-identical to the reusable workflow before converting — a clean mechanical extraction, no behavior change. New required-status-check context (if this job is ever added to branch protection): `call / automerge`.

## Left AS-IS — do not cleanly match the current 6-workflow catalog

This repo's actual CI (verified by reading job logic, not filenames) has diverged substantially from the assumptions baked into the reusable-workflow catalog piloted on scitex-stats (self-hosted `spartan-cpu` runner, `uv`-based installs, simple job bodies). Forcing a conversion here would silently change behavior or point at an unverified runner, so per the task brief these are left untouched:

- **`pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`** — runs on `ubuntu-latest` (not self-hosted `spartan-cpu`), with CPU-torch pre-pinning, peer-standalone package installs, a PS-170 umbrella-pin-freshness audit step, and a segfault-retry + JUnit-report pass/fail decoupling scheme (the ecosystem's C-extension stack segfaults non-deterministically at interpreter shutdown/import). None of that exists in the reusable `pytest-matrix.yml`. Converting would drop safety-critical logic and could target a self-hosted runner label this repo may not have.
- **`import-smoke-on-ubuntu-py3-12.yml`** — `ubuntu-latest`, plain `pip`/`venv`, hardcoded `import scitex`, vs. the reusable workflow's self-hosted/`uv`/derived-package-name approach.
- **`scitex-quality-audit-on-ubuntu-latest.yml`** — this audits the **whole ecosystem** (shallow-clones every `scitex-*` repo and runs `scripts/quality/audit_ecosystem.py`), not just the calling repo. The reusable `quality-audit.yml` audits only the calling repo's own `pyproject.toml`-derived package — different job semantics entirely, not a naming coincidence.
- **`rtd-sphinx-build-on-ubuntu-latest.yml`** — beyond building Sphinx HTML, this job also commits the built bundle back into `src/scitex/_sphinx_html/` on `develop` pushes (feeds production doc serving). The reusable `rtd-sphinx-build.yml` only builds and exits. Converting would silently drop the commit-back step.
- **`cla.yml`** — has no `push` trigger and no owner-bypass job (simpler than the reusable `cla.yml`), and authenticates with a secret named `CLA_PERSONAL_ACCESS_TOKEN`, while the reusable workflow hardcodes `secrets.GH_PERSONAL_ACCESS_TOKEN`. Converting risked silently breaking the CLA-signature-branch push for non-allowlisted contributors (the env var would resolve empty). Flagging for a follow-up once the secret naming is reconciled.
- **`newb.yml`** / **`newb-docs-quality-on-ubuntu-latest.yml`** — no reusable-workflow equivalent exists yet for this doc-quality-via-LLM job (two near-duplicate files already present in this repo, independent of this migration).
- **`pypi-publish-and-github-release-on-tag.yml`** (the tag-driven `release` workflow) — untouched per explicit instruction: PyPI OIDC trusted publishing does not support `workflow_call` (`invalid-publisher`), and this file's own comments already document why it must stay local + SIF-based.

## Branch protection

Checked `gh api repos/ywatanabe1989/scitex-python/branches/{develop,main}/protection` — both return 404 ("Branch protection has been disabled on this repository"). No required-status-check contexts to update.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` passes on the one edited file.
- Diff is job-body-only; `on:`/`permissions:` blocks are byte-identical to the pre-PR file.

## Do not merge

Per task instructions this PR is left for review.